### PR TITLE
feat: explode/rehash

### DIFF
--- a/features/git-mob/explode.feature
+++ b/features/git-mob/explode.feature
@@ -1,0 +1,34 @@
+Feature: explode
+
+  Background:
+  Scenario: creates helper plugins
+    Given I have installed go-git-mob into "local_bin" within the current directory
+    And I look for executables in "local_bin" within the current directory
+    When I run `git mob explode`
+    Then a file named "local_bin/git-mob" should exist
+    And a file named "local_bin/git-mob-print" should exist
+    And a file named "local_bin/git-mob-version" should exist
+    And a file named "local_bin/git-solo" should exist
+    And a file named "local_bin/git-suggest-coauthors" should exist
+
+  Scenario: helper-plugins work: mob-version
+    Given I have installed go-git-mob into "local_bin" within the current directory
+    And I look for executables in "local_bin" within the current directory
+    When I run `git mob explode`
+    And I run `git mob-version`
+    Then the output should contain "git-mob"
+
+  Scenario: helper-plugins work: suggest-coauthors
+    Given I have installed go-git-mob into "local_bin" within the current directory
+    And I look for executables in "local_bin" within the current directory
+    And I run `git config --global user.name "Jane Doe"`
+    And I run `git config --global user.email "jane@example.com"`
+    And a simple git repo at "example"
+    When I cd to "example"
+    And I run `git mob explode`
+    And I run `git suggest-coauthors`
+    Then the output should contain:
+      """
+      Here are some suggestions for coauthors based on existing authors of this repository:
+      git mob add-coauthor JD Jane Doe jane@example.com
+      """

--- a/features/step_definitions/installation_steps.rb
+++ b/features/step_definitions/installation_steps.rb
@@ -1,0 +1,25 @@
+require 'fileutils'
+
+Given('I have installed go-git-mob into my path') do
+  bin = File.join(aruba.root_directory, 'bin', 'git-mob')
+  raise "'#{bin}' not found; did you run 'make build'?" unless File.exist?(bin)
+
+  local_bin_folder = 'bin'
+  create_directory(local_bin_folder)
+  FileUtils.cp(bin, File.join(aruba.current_directory, local_bin_folder))
+  prepend_environment_variable(
+    "PATH",
+    expand_path(local_bin_folder) + File::PATH_SEPARATOR
+  )
+
+  run_command_and_stop('which git-mob', fail_on_error: true)
+end
+
+Given('I have installed go-git-mob into {string} within the current directory') do |path|
+  exe = File.join(aruba.root_directory, 'bin', 'git-mob')
+  raise "'#{exe}' not found; did you run 'make build'?" unless File.exist?(exe)
+
+  create_directory(path)
+  FileUtils.cp(exe, File.join(aruba.current_directory, path))
+  run_command_and_stop("ls -la #{path}", fail_on_error: true)
+end

--- a/features/step_definitions/pending_steps.rb
+++ b/features/step_definitions/pending_steps.rb
@@ -1,0 +1,3 @@
+When('pending') do
+  pending # Write code here that turns the phrase above into concrete actions
+end

--- a/internal/cmd/explode.go
+++ b/internal/cmd/explode.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/davidalpert/go-git-mob/internal/cmd/utils"
+	"github.com/spf13/cobra"
+	"os"
+	"path"
+)
+
+type ExplodeOptions struct {
+	*utils.PrinterOptions
+	utils.IOStreams
+}
+
+func NewExplodeOptions(ioStreams utils.IOStreams) *ExplodeOptions {
+	return &ExplodeOptions{
+		IOStreams:      ioStreams,
+		PrinterOptions: utils.NewPrinterOptions().WithDefaultOutput("text"),
+	}
+}
+
+func NewCmdExplode(ioStreams utils.IOStreams) *cobra.Command {
+	o := NewExplodeOptions(ioStreams)
+	var cmd = &cobra.Command{
+		Use:     "explode",
+		Short:   "creates helper git plugin scripts",
+		Aliases: []string{"rehash"},
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(cmd, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			return o.Run()
+		},
+	}
+
+	o.PrinterOptions.AddPrinterFlags(cmd)
+
+	return cmd
+}
+
+// Complete the options
+func (o *ExplodeOptions) Complete(cmd *cobra.Command, args []string) error {
+	return nil
+}
+
+// Validate the options
+func (o *ExplodeOptions) Validate() error {
+	return o.PrinterOptions.Validate()
+}
+
+// Run the command
+func (o *ExplodeOptions) Run() error {
+	cmdMap := map[string]string{
+		"git-mob-print":         "git-mob print",
+		"git-mob-version":       "git-mob version",
+		"git-solo":              "git-mob solo",
+		"git-suggest-coauthors": "git-mob coauthors suggest",
+	}
+
+	e, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	eDir := path.Dir(e)
+
+	for plugin, cmd := range cmdMap {
+		p := fmt.Sprintf("%s", path.Join(eDir, plugin))
+		c := fmt.Sprintf(`
+#!/bin/sh
+%s
+`, cmd)
+
+		fmt.Println("writing:", p)
+		if err := os.WriteFile(p, []byte(c), 0755); err != nil {
+			return fmt.Errorf("writing '%s': %v", p, err)
+		}
+	}
+
+	//return o.IOStreams.WriteOutput(cmdMap, o.PrinterOptions.WithDefaultOutput("json"))
+	return nil
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -67,6 +67,7 @@ A git plugin to help manage git coauthors.
 	rootCmd.AddCommand(NewCmdMob(ioStreams))
 	rootCmd.AddCommand(NewCmdSolo(ioStreams))
 	rootCmd.AddCommand(NewCmdCoauthors(ioStreams))
+	rootCmd.AddCommand(NewCmdExplode(ioStreams))
 	rootCmd.AddCommand(NewCmdVersion(ioStreams))
 	rootCmd.AddCommand(NewCmdPrint(ioStreams))
 


### PR DESCRIPTION
this command creates simple shims redirecting
the original multitude of git plugins to
git-mob subcommands; this allows us to ship
a single git-mob exe and 'explode' it into
the same multiple git plugin footprint and
usage experience as the original node app

resolves #16