### PR TITLE
refactor: remove duplication in explode.feature

### DIFF
--- a/features/git-mob/explode.feature
+++ b/features/git-mob/explode.feature
@@ -1,9 +1,12 @@
 Feature: explode
 
   Background:
-  Scenario: creates helper plugins
-    Given I have installed go-git-mob into "local_bin" within the current directory
+    Given I run `git config --global user.name "Jane Doe"`
+    And I run `git config --global user.email "jane@example.com"`
+    And I have installed go-git-mob into "local_bin" within the current directory
     And I look for executables in "local_bin" within the current directory
+
+  Scenario: creates helper plugins
     When I run `git mob explode`
     Then a file named "local_bin/git-mob" should exist
     And a file named "local_bin/git-mob-print" should exist
@@ -12,20 +15,14 @@ Feature: explode
     And a file named "local_bin/git-suggest-coauthors" should exist
 
   Scenario: helper-plugins work: mob-version
-    Given I have installed go-git-mob into "local_bin" within the current directory
-    And I look for executables in "local_bin" within the current directory
     When I run `git mob explode`
     And I run `git mob-version`
     Then the output should contain "git-mob"
 
   Scenario: helper-plugins work: suggest-coauthors
-    Given I have installed go-git-mob into "local_bin" within the current directory
-    And I look for executables in "local_bin" within the current directory
-    And I run `git config --global user.name "Jane Doe"`
-    And I run `git config --global user.email "jane@example.com"`
-    And a simple git repo at "example"
-    When I cd to "example"
-    And I run `git mob explode`
+    Given a simple git repo at "example"
+    When I run `git mob explode`
+    And I cd to "example"
     And I run `git suggest-coauthors`
     Then the output should contain:
       """

--- a/features/git-mob/implode.feature
+++ b/features/git-mob/implode.feature
@@ -1,0 +1,29 @@
+Feature: implode
+
+  Background:
+    Given I run `git config --global user.name "Jane Doe"`
+    And I run `git config --global user.email "jane@example.com"`
+    And I have installed go-git-mob into "local_bin" within the current directory
+    And I look for executables in "local_bin" within the current directory
+    And I run `git mob explode`
+    And a file named "local_bin/git-mob" should exist
+    And a file named "local_bin/git-mob-print" should exist
+    And a file named "local_bin/git-mob-version" should exist
+    And a file named "local_bin/git-solo" should exist
+    And a file named "local_bin/git-suggest-coauthors" should exist
+
+  Scenario: removes helper plugins and itself
+    When I run `git mob implode`
+    Then a file named "local_bin/git-mob-print" should not exist
+    And a file named "local_bin/git-mob-version" should not exist
+    And a file named "local_bin/git-solo" should not exist
+    And a file named "local_bin/git-suggest-coauthors" should not exist
+    And a file named "local_bin/git-mob" should not exist
+
+  Scenario: aliased to uninstall
+    When I run `git mob uninstall`
+    Then a file named "local_bin/git-mob-print" should not exist
+    And a file named "local_bin/git-mob-version" should not exist
+    And a file named "local_bin/git-solo" should not exist
+    And a file named "local_bin/git-suggest-coauthors" should not exist
+    And a file named "local_bin/git-mob" should not exist

--- a/features/git-mob/mob.feature
+++ b/features/git-mob/mob.feature
@@ -19,10 +19,9 @@ Feature: mob
     }
     """
     And a simple git repo at "example"
-    And I cd to "example"
 
-  # @announce-stdout @announce-stderr
   Scenario: start mob with one coauthor
+    Given I cd to "example"
     When I run git mob `ad`
     Then the output should contain:
     """
@@ -35,8 +34,16 @@ Feature: mob
     \tco-author = Amy Doe <amy@findmypast.com>
     """
 
-  # @announce-stdout @announce-stderr
+  Scenario: start mob with a nonexistant coauthor
+    Given I cd to "example"
+    When I run git mob `be`
+    Then the output should contain:
+    """
+    could not find coauthor with initials 'be'; run 'git mob --list' to see a list of available co-authors
+    """
+
   Scenario: start mob with two coauthors
+    Given I cd to "example"
     When I run git mob `ad bd`
     Then the output should contain:
     """
@@ -52,6 +59,7 @@ Feature: mob
     """
 
   Scenario: change coauthors
+    Given I cd to "example"
     When I run git mob `ad`
     And I run git mob `bd`
     Then the output should contain:
@@ -63,4 +71,13 @@ Feature: mob
     """
     [git-mob]
     \tco-author = Bob Doe <bob@findmypast.com>
+    """
+
+  Scenario: no git-coauthors file
+    Given I remove the file "~/.git-coauthors"
+    And I cd to "example"
+    When I run git mob `ad`
+    Then the output should contain:
+    """
+    could not find coauthor with initials 'ad'; run 'git mob --list' to see a list of available co-authors
     """

--- a/internal/authors/authors.go
+++ b/internal/authors/authors.go
@@ -72,6 +72,9 @@ func ReadCoAuthorsContent() (CoAuthorsFileContent, error) {
 }
 
 func ReadCoAuthorsContentFromFile(filePath string) (CoAuthorsFileContent, error) {
+	if err := EnsureCoauthorsFileExists(filePath); err != nil {
+		return CoAuthorsFileContent{}, nil
+	}
 	b, err := os.ReadFile(filePath)
 	if err != nil {
 		return CoAuthorsFileContent{}, err
@@ -125,8 +128,8 @@ func (f CoAuthorsFileContent) FindInitialsFromCoAuthorStrings(ss ...string) []st
 	return result
 }
 
-func EnsureCoauthorsFileExists() error {
-	if _, err := os.Stat(CoAuthorsFilePath); os.IsNotExist(err) {
+func EnsureCoauthorsFileExists(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
 		cc := CoAuthorsFileContent{
 			CoAuthorsByInitial: make(map[string]Author, 0),
 		}
@@ -135,7 +138,7 @@ func EnsureCoauthorsFileExists() error {
 			return err
 		}
 
-		return os.WriteFile(CoAuthorsFilePath, b, os.ModePerm)
+		return os.WriteFile(path, b, os.ModePerm)
 	}
 	return nil
 }

--- a/internal/cmd/explode.go
+++ b/internal/cmd/explode.go
@@ -55,20 +55,13 @@ func (o *ExplodeOptions) Validate() error {
 
 // Run the command
 func (o *ExplodeOptions) Run() error {
-	cmdMap := map[string]string{
-		"git-mob-print":         "git-mob print",
-		"git-mob-version":       "git-mob version",
-		"git-solo":              "git-mob solo",
-		"git-suggest-coauthors": "git-mob coauthors suggest",
-	}
-
 	e, err := os.Executable()
 	if err != nil {
 		return err
 	}
 	eDir := path.Dir(e)
 
-	for plugin, cmd := range cmdMap {
+	for plugin, cmd := range GitMobPluginMap {
 		p := fmt.Sprintf("%s", path.Join(eDir, plugin))
 		c := fmt.Sprintf(`
 #!/bin/sh
@@ -81,6 +74,12 @@ func (o *ExplodeOptions) Run() error {
 		}
 	}
 
-	//return o.IOStreams.WriteOutput(cmdMap, o.PrinterOptions.WithDefaultOutput("json"))
 	return nil
+}
+
+var GitMobPluginMap = map[string]string{
+	"git-mob-print":         "git-mob print",
+	"git-mob-version":       "git-mob version",
+	"git-solo":              "git-mob solo",
+	"git-suggest-coauthors": "git-mob coauthors suggest",
 }

--- a/internal/cmd/implode.go
+++ b/internal/cmd/implode.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/davidalpert/go-git-mob/internal/cmd/utils"
+	"github.com/spf13/cobra"
+	"os"
+	"path"
+)
+
+type ImplodeOptions struct {
+	*utils.PrinterOptions
+	utils.IOStreams
+}
+
+func NewImplodeOptions(ioStreams utils.IOStreams) *ImplodeOptions {
+	return &ImplodeOptions{
+		IOStreams:      ioStreams,
+		PrinterOptions: utils.NewPrinterOptions().WithDefaultOutput("text"),
+	}
+}
+
+func NewCmdImplode(ioStreams utils.IOStreams) *cobra.Command {
+	o := NewImplodeOptions(ioStreams)
+	var cmd = &cobra.Command{
+		Use:     "implode",
+		Short:   "removes helper git plugin scripts",
+		Aliases: []string{"uninstall"},
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(cmd, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			return o.Run()
+		},
+	}
+
+	o.PrinterOptions.AddPrinterFlags(cmd)
+
+	return cmd
+}
+
+// Complete the options
+func (o *ImplodeOptions) Complete(cmd *cobra.Command, args []string) error {
+	return nil
+}
+
+// Validate the options
+func (o *ImplodeOptions) Validate() error {
+	return o.PrinterOptions.Validate()
+}
+
+// Run the command
+func (o *ImplodeOptions) Run() error {
+	e, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	eDir := path.Dir(e)
+
+	for plugin, _ := range GitMobPluginMap {
+		p := fmt.Sprintf("%s", path.Join(eDir, plugin))
+
+		if _, err = os.Stat(p); err == nil {
+			fmt.Println("removing:", p)
+			if err := os.Remove(p); err != nil {
+				return fmt.Errorf("removing '%s': %v", p, err)
+			}
+		}
+	}
+
+	fmt.Println("attempting to remove:", e)
+	return os.Remove(e)
+}

--- a/internal/cmd/mob.go
+++ b/internal/cmd/mob.go
@@ -132,6 +132,9 @@ func (o *MobOptions) setMob() error {
 				break
 			}
 		}
+		if coauthors[i].Name == "" {
+			return fmt.Errorf("could not find coauthor with initials '%s'; run 'git mob --list' to see a list of available co-authors", initial)
+		}
 	}
 
 	if err := cfg.ResetMob(); err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -75,6 +75,7 @@ A git plugin to help manage git coauthors.
 	rootCmd.AddCommand(NewCmdSolo(ioStreams))
 	rootCmd.AddCommand(NewCmdCoauthors(ioStreams))
 	rootCmd.AddCommand(NewCmdExplode(ioStreams))
+	rootCmd.AddCommand(NewCmdImplode(ioStreams))
 	rootCmd.AddCommand(NewCmdVersion(ioStreams))
 	rootCmd.AddCommand(NewCmdPrint(ioStreams))
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -24,6 +24,13 @@ func Execute() {
 			if a.Name() == b {
 				cmdFound = true
 				break
+			} else {
+				for _, alias := range a.Aliases {
+					if alias == b {
+						cmdFound = true
+						break
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
starting a mob with a coauthor whose initials did not exist in the
.git-coauthors file would succeed with an empty entry (blank
name and blank email)

this commit (a) ensures that the coauthors file exists and
(b) returns an error if the requested initials are not found in
that file.

in this way we can better recognize when adding a new
subcommand we will see it as a miss since the subcommand
will not appear in the test .git-coauthors file