### PR TITLE
refactor: collect git paths into a revParse module

### DIFF
--- a/internal/cfg/config.go
+++ b/internal/cfg/config.go
@@ -122,44 +122,6 @@ func SetCoAuthors() error {
 	return nil
 }
 
-func InsideWorkTree() bool {
-	_, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{
-		DetectDotGit:          true,
-		EnableDotGitCommonDir: false,
-	})
-	if err == git.ErrRepositoryNotExists {
-		return false
-	}
-	return true
-}
-
-// TopLevelDirectory computes the path to the top-level directory of the git repository.
-func TopLevelDirectory() string {
-	r, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{
-		DetectDotGit:          true,
-		EnableDotGitCommonDir: false,
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	w, err := r.Worktree()
-	if err != nil {
-		panic(err)
-	}
-
-	return w.Filesystem.Root()
-}
-
-// GitPath resolves the given path to the .git directory (GIT_DIR).
-// from https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables#_repository_locations
-// GIT_DIR is the location of the .git folder. If this isn’t specified,
-// Git walks up the directory tree until it gets to ~ or /, looking for a
-// .git directory at every step.
-func GitPath(rel ...string) string {
-	return path.Join(append([]string{TopLevelDirectory(), ".git"}, rel...)...)
-}
-
 func ReadAllCoAuthorsFromFile() (map[string]authors.Author, error) {
 	c, e := authors.ReadCoAuthorsContent()
 	if e != nil {

--- a/internal/cfg/config.go
+++ b/internal/cfg/config.go
@@ -1,80 +1,165 @@
 package cfg
 
 import (
+	"bytes"
 	"fmt"
 	"github.com/davidalpert/go-git-mob/internal/authors"
 	"github.com/davidalpert/go-git-mob/internal/env"
-	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
-	"github.com/go-git/go-git/v5/plumbing/object"
-	"os"
+	"os/exec"
 	"path"
 	"strings"
 )
 
 // Get gets the (last) value for the given option key.
 func Get(key string) string {
-	parts := strings.Split(key, ".")
-	if len(parts) < 2 {
-		return ""
-	}
-
-	c, err := config.LoadConfig(config.GlobalScope)
+	o, err := silentRun("git", "config", "--get", key)
 	if err != nil {
 		return ""
 	}
-
-	if c.Raw.HasSection(parts[0]) {
-		s := c.Raw.Section(parts[0])
-		return s.Option(parts[1])
-	}
-
-	return ""
+	return o
 }
 
 // GetAll gets all values for a multi-valued option key.
 func GetAll(key string) ([]string, error) {
-	return nil, nil
+	o, err := silentRun("git", "config", "--all", key)
+	if err != nil {
+		return make([]string, 0), err
+	}
+	return strings.Split(o, "\n"), nil
 }
 
-// ResetMob clears out the co-authors from global git config
-func ResetMob() error {
-	c, err := config.LoadConfig(config.GlobalScope)
+// Set sets the option, overwriting the existing value if one exists.
+func Set(key string, value string) error {
+	//const { status } = silentRun(`git config ${key} "${value}"`);
+	_, err := silentRun("git", "config", key, value)
 	if err != nil {
-		return err
+		return fmt.Errorf("option '%s' has multiple values. Cannot overwrite multiple values for option '%s' with a single value", key, key)
 	}
-
-	if c.Raw.HasSection("git-mob") {
-		s := c.Raw.Section("git-mob")
-		s.RemoveOption("co-author")
-		return writeConfig(c)
-	}
-
 	return nil
 }
 
-// writeConfig saves the in-memory git config back to the global gitconfig file
-func writeConfig(c *config.Config) error {
-	b, err := c.Marshal()
+// SetGlobal sets the global option, overwriting the existing value if one exists.
+func SetGlobal(key string, value string) error {
+	//const { status } = silentRun(`git config ${key} "${value}"`);
+	_, err := silentRun("git", "config", "--global", key, value)
 	if err != nil {
-		return err
+		return fmt.Errorf("option '%s' has multiple values. Cannot overwrite multiple values for option '%s' with a single value", key, key)
+	}
+	return nil
+}
+
+// Add adds a new line to the option without altering any existing values.
+func Add(key string, value string) error {
+	_, err := silentRun("git", "config", "--add", key, value)
+	return err
+}
+
+// AddGlobal adds a new line to the global option without altering any existing values.
+func AddGlobal(key string, value string) error {
+	_, err := silentRun("git", "config", "--global", "--add", key, value)
+	return err
+}
+
+// silentRun runs the given command in a shell.
+func silentRun(name string, arg ...string) (string, error) {
+	c := exec.Command(name, arg...)
+	//c.Stdin = strings.NewReader("and old falcon")
+
+	if env.GetValueOrDefaultBool("GITMOB_DEBUG", false) {
+		fmt.Printf("silentRun: %s %s\n", name, strings.Join(arg, " "))
 	}
 
-	return os.WriteFile(GlobalConfigFilePath, b, os.ModePerm)
+	var out bytes.Buffer
+	c.Stdout = &out
+	var stdErr bytes.Buffer
+	c.Stderr = &stdErr
+
+	if err := c.Run(); err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("nonzero exit code: %d: %s %s", exitError.ExitCode(), out.String(), stdErr.String())
+		}
+		return "", err
+	}
+
+	if env.GetValueOrDefaultBool("GITMOB_DEBUG", false) {
+		fmt.Println(out.String())
+	}
+
+	return strings.TrimSpace(out.String()), nil
+}
+
+// Has checks if the given option exists in the configuration.
+func Has(key string) bool {
+	_, err := silentRun("git", "config", key)
+	return err == nil
+}
+
+// HasGlobal checks if the given option exists in the global configuration.
+func HasGlobal(key string) bool {
+	_, err := silentRun("git", "config", "--global", key)
+	return err == nil
+}
+
+// RemoveSection removes the given section from the configuration.
+func RemoveSection(key string) error {
+	if Has(key) {
+		_, err := silentRun("git", "config", "--remove-section", key)
+		return err
+	}
+	return nil
+}
+
+// RemoveSectionGlobal removes the given section from the global configuration.
+func RemoveSectionGlobal(key string) error {
+	if HasGlobal(key) {
+		_, err := silentRun("git", "config", "--global", "--remove-section", key)
+		return err
+	}
+	return nil
+}
+
+// Remove removes the given key from the configuration.
+func Remove(key string) error {
+	if Has(key) {
+		_, err := silentRun("git", "config", "--unset", key)
+		return err
+	}
+	return nil
+}
+
+// RemoveAll removes all the given keys from the configuration.
+func RemoveAll(key string) error {
+	if Has(key) {
+		_, err := silentRun("git", "config", "--unset-all", key)
+		return err
+	}
+	return nil
+}
+
+// RemoveGlobal removes the given key from the configuration.
+func RemoveGlobal(key string) error {
+	if HasGlobal(key) {
+		_, err := silentRun("git", "config", "--global", "--unset", key)
+		return err
+	}
+	return nil
+}
+
+// RemoveAllGlobal removes all the given keys from the configuration.
+func RemoveAllGlobal(key string) error {
+	if HasGlobal(key) {
+		_, err := silentRun("git", "config", "--global", "--unset-all", key)
+		return err
+	}
+	return nil
 }
 
 func AddCoAuthors(aa ...authors.Author) error {
-	c, err := config.LoadConfig(config.GlobalScope)
-	if err != nil {
-		return err
-	}
-
 	for _, a := range aa {
-		c.Raw.AddOption("git-mob", "", "co-author", fmt.Sprintf("%s <%s>", a.Name, a.Email))
-	}
-
-	if len(aa) > 0 {
-		return writeConfig(c)
+		if err := AddGlobal("git-mob.co-author", a.String()); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -133,44 +218,24 @@ func ReadAllCoAuthorsFromFile() (map[string]authors.Author, error) {
 
 func ShortLogAuthorSummary() (map[string]authors.Author, error) {
 	// git shortlog --summary --email --number HEAD'
-
-	r, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{
-		DetectDotGit:          true,
-		EnableDotGitCommonDir: false,
-	})
-	if err == git.ErrRepositoryNotExists {
-		return nil, fmt.Errorf("not a git repository")
-	}
-
-	commitIter, err := r.Log(&git.LogOptions{
-		All: true, // TODO: make this more performant
-	})
+	o, err := silentRun("git", "shortlog", "--summary", "--email", "--number", "HEAD")
 	if err != nil {
-		return nil, fmt.Errorf("error reading git log: %v", err)
+		return nil, fmt.Errorf("error reading git shortlog: %v", err)
 	}
 
-	foundAuthorsByEmail := make(map[string]authors.Author, 0)
-	err = commitIter.ForEach(func(c *object.Commit) error {
-		if _, found := foundAuthorsByEmail[c.Author.Email]; !found {
-			foundAuthorsByEmail[c.Author.Email] = authors.Author{
-				Name:  c.Author.Name,
-				Email: c.Author.Email,
-			}
+	result := make(map[string]authors.Author, 0)
+	for _, line := range strings.Split(o, "\n") {
+		parts := strings.Split(line, "\t")
+		if len(parts) > 3 {
+			return nil, fmt.Errorf("shortlog line contained %d parts; expected 3: %#v", len(parts), parts)
 		}
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("error iterating through git commits: %v", err)
-	}
-
-	result := make(map[string]authors.Author)
-	for _, a := range foundAuthorsByEmail {
-		result[a.InitialsFromName()] = authors.Author{
-			Name:  a.Name,
-			Email: a.Email,
+		s := strings.Join(parts[1:], " ")
+		if a, err := authors.ParseOne(s); err != nil {
+			return nil, fmt.Errorf("parsing '%s' as author: %v", s, err)
+		} else {
+			result[a.InitialsFromName()] = a
 		}
 	}
-
 	return result, nil
 }
 

--- a/internal/cmd/coauthors_suggest.go
+++ b/internal/cmd/coauthors_suggest.go
@@ -5,6 +5,7 @@ import (
 	"github.com/davidalpert/go-git-mob/internal/authors"
 	"github.com/davidalpert/go-git-mob/internal/cfg"
 	"github.com/davidalpert/go-git-mob/internal/cmd/utils"
+	"github.com/davidalpert/go-git-mob/internal/revParse"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	"sort"
@@ -51,7 +52,7 @@ func (o *CoauthorsSuggestOptions) Complete(cmd *cobra.Command, args []string) er
 
 // Validate the options
 func (o *CoauthorsSuggestOptions) Validate() error {
-	if !cfg.InsideWorkTree() {
+	if !revParse.InsideWorkTree() {
 		return fmt.Errorf("not a git repository")
 	}
 

--- a/internal/cmd/mob.go
+++ b/internal/cmd/mob.go
@@ -137,9 +137,10 @@ func (o *MobOptions) setMob() error {
 		}
 	}
 
-	if err := cfg.ResetMob(); err != nil {
-		return nil
+	if err := resetMob(); err != nil {
+		return err
 	}
+	fmt.Printf("coauthors: %#v\n", coauthors)
 	if err := cfg.AddCoAuthors(coauthors...); err != nil {
 		return err
 	}
@@ -163,6 +164,10 @@ func (o *MobOptions) setMob() error {
 		}
 	}
 
-	o.WriteStringln(strings.Join(append([]string{meTag}, parts...), "\n"))
-	return nil
+	return o.WriteStringln(strings.Join(append([]string{meTag}, parts...), "\n"))
+}
+
+// resetMob clears out the co-authors from global git config
+func resetMob() error {
+	return cfg.RemoveAllGlobal("git-mob.co-author")
 }

--- a/internal/cmd/solo.go
+++ b/internal/cmd/solo.go
@@ -54,7 +54,7 @@ func (o *SoloOptions) Validate() error {
 
 // Run the command
 func (o *SoloOptions) Run() error {
-	if err := cfg.ResetMob(); err != nil {
+	if err := resetMob(); err != nil {
 		return err
 	}
 

--- a/internal/msg/message.go
+++ b/internal/msg/message.go
@@ -5,6 +5,7 @@ import (
 	"github.com/davidalpert/go-git-mob/internal/authors"
 	"github.com/davidalpert/go-git-mob/internal/cfg"
 	"github.com/davidalpert/go-git-mob/internal/env"
+	"github.com/davidalpert/go-git-mob/internal/revParse"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -25,7 +26,7 @@ const (
 )
 
 func GitMessagePath() string {
-	return env.GetValueOrDefault(EnvKeyGitMessagePath, cfg.GitPath(".gitmessage"))
+	return env.GetValueOrDefault(EnvKeyGitMessagePath, revParse.GitPath(".gitmessage"))
 }
 
 func CommitTemplatePath() string {

--- a/internal/revParse/paths.go
+++ b/internal/revParse/paths.go
@@ -1,0 +1,46 @@
+package revParse
+
+import (
+	"github.com/go-git/go-git/v5"
+	"path"
+)
+
+// InsideWorkTree checks if the current working directory is inside the working tree of a git repository.
+// returns true if the cwd in a git repository.
+func InsideWorkTree() bool {
+	_, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{
+		DetectDotGit:          true,
+		EnableDotGitCommonDir: false,
+	})
+	if err == git.ErrRepositoryNotExists {
+		return false
+	}
+	return true
+}
+
+// TopLevelDirectory computes the path to the top-level directory of the git repository.
+func TopLevelDirectory() string {
+	r, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{
+		DetectDotGit:          true,
+		EnableDotGitCommonDir: false,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	w, err := r.Worktree()
+	if err != nil {
+		panic(err)
+	}
+
+	return w.Filesystem.Root()
+}
+
+// GitPath resolves the given path to the .git directory (GIT_DIR).
+// from https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables#_repository_locations
+// GIT_DIR is the location of the .git folder. If this isn’t specified,
+// Git walks up the directory tree until it gets to ~ or /, looking for a
+// .git directory at every step.
+func GitPath(rel ...string) string {
+	return path.Join(append([]string{TopLevelDirectory(), ".git"}, rel...)...)
+}


### PR DESCRIPTION
- includes adding additional git config functions
  to match the git-mob config helpers

- still use go-git for revParse functions; it seems
  stable there and simpler than parsing the git --version
  output

resolve #21