### PR TITLE
feat: init & auto append coauthor to a commit with the message flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,11 +78,11 @@ test-unit: ./internal/version/detail.go ## run unit tests
 
 .PHONY: test-features
 test-features: Gemfile.lock build ## Run cucumber/aruba backend features
-	bundle exec cucumber --publish-quiet --tags 'not @wip'
+	bundle exec cucumber --publish-quiet --tags 'not @wip' --tags 'not @ignore'
 
 .PHONY: test-features-wip
 test-features-wip: Gemfile.lock build ## Run cucumber/aruba backend features
-	bundle exec cucumber --publish-quiet --tags '@wip'
+	bundle exec cucumber --publish-quiet --tags '@wip' --tags 'not @ignore'
 
 .PHONY: depgraph
 depgraph: ## create a dotgraph visualizing package dependencies

--- a/features/git-mob/mob-appends-coauthors-to-commits.feature
+++ b/features/git-mob/mob-appends-coauthors-to-commits.feature
@@ -1,0 +1,25 @@
+Feature: git mob appends coauthors to commits
+
+  Background:
+    Given I have installed go-git-mob into "local_bin" within the current directory
+    And I look for executables in "local_bin" within the current directory
+    And a file named "~/.gitconfig" with:
+      """
+      [user]
+      name = Jane Doe
+      email = jane@example.com
+
+      [git-mob]
+      co-author = Amy Doe <amy@findmypast.com>
+      """
+    And a simple git repo at "example"
+
+  # @announce-git-log
+  Scenario: append coauthor to a commit with the message flag
+    Given I cd to "example"
+    And I successfully run `git mob init`
+    And I successfully run `git commit --allow-empty -m "empty mobbed commit"`
+    Then the most recent commit log should contain:
+      """
+      Co-Authored-By: Amy Doe <amy@findmypast.com>
+      """

--- a/features/git-mob/mob-init.feature
+++ b/features/git-mob/mob-init.feature
@@ -1,0 +1,37 @@
+Feature: mob-init
+
+  Background:
+    Given I have installed go-git-mob into "local_bin" within the current directory
+    And I look for executables in "local_bin" within the current directory
+    And a file named "~/.gitconfig" with:
+      """
+      [user]
+      name = Jane Doe
+      email = jane@example.com
+
+      [git-mob]
+      co-author = Amy Doe <amy@findmypast.com>
+      """
+
+  Scenario: initialize git-mob inside a given repo
+    Given a simple git repo at "example"
+    When I cd to "example"
+    And I successfully run `git mob init`
+    Then the file ".git/hooks/prepare-commit-msg" should exist
+    And the file ".git/hooks/prepare-commit-msg" should contain:
+      """
+      #!/bin/sh
+
+      COMMIT_MSG_FILE=$1
+      COMMIT_SOURCE=$2
+      SHA1=$3
+
+      set -e
+
+      git mob prepare-commit-msg "$COMMIT_MSG_FILE" $COMMIT_SOURCE $SHA1
+      """
+    And the output should contain:
+      """
+      initialized local git hook: '.git/hooks/prepare-commit-msg'
+      git-mob will now help prepare commit messages in this repo
+      """

--- a/features/git-mob/mob-prepare-commit-msg.feature
+++ b/features/git-mob/mob-prepare-commit-msg.feature
@@ -1,0 +1,51 @@
+Feature: mob prepare-commit-msg
+
+  Background:
+    Given I have installed go-git-mob into "local_bin" within the current directory
+    And I look for executables in "local_bin" within the current directory
+
+    Given a file named "~/.gitconfig" with:
+      """
+      [user]
+      name = Jane Doe
+      email = jane@example.com
+
+      [git-mob]
+      co-author = Amy Doe <amy@findmypast.com>
+      """
+
+  Scenario: one coauthor - message - empty message
+    Given an empty file ".git/COMMIT_EDITMSG"
+    And I successfully run `git mob prepare-commit-msg .git/COMMIT_EDITMSG message`
+    Then the file ".git/COMMIT_EDITMSG" should contain:
+      """
+
+      Co-Authored-By: Amy Doe <amy@findmypast.com>
+      """
+
+  Scenario: one coauthor - message - message with comments
+    Given a file named ".git/COMMIT_EDITMSG" with:
+      """
+      Add something awesome
+
+      # Please enter the commit message for your changes. Lines starting
+      # with '#' will be ignored, and an empty message aborts the commit.
+      #
+      # On branch 23-feat-append-to-commit-message
+      # Your branch is up to date with 'origin/23-feat-append-to-commit-message'.
+      #
+      """
+    And I successfully run `git mob prepare-commit-msg .git/COMMIT_EDITMSG message`
+    Then the file ".git/COMMIT_EDITMSG" should contain:
+      """
+      Add something awesome
+
+      Co-Authored-By: Amy Doe <amy@findmypast.com>
+
+      # Please enter the commit message for your changes. Lines starting
+      # with '#' will be ignored, and an empty message aborts the commit.
+      #
+      # On branch 23-feat-append-to-commit-message
+      # Your branch is up to date with 'origin/23-feat-append-to-commit-message'.
+      #
+      """

--- a/features/step_definitions/repo_steps.rb
+++ b/features/step_definitions/repo_steps.rb
@@ -43,3 +43,16 @@ Given('a simple git repo at {string} with the following empty commits:') do |pat
     run_command_and_stop('git config --remove-section user', fail_on_error: true)
   end
 end
+
+Then('the most recent commit log should contain:') do |doc_string|
+  msg = 'TBD'
+
+  Dir.chdir(aruba.current_directory) do
+    msg = `git log -1 --format=full`
+  end
+
+  aruba.announcer.announce(:git_log, msg)
+
+  expect(msg)
+    .to match_string doc_string
+end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -3,3 +3,7 @@ end
 
 After do
 end
+
+Before('@announce-git-log') do
+  aruba.announcer.activate :git_log
+end

--- a/features/support/matchers/match_string.rb
+++ b/features/support/matchers/match_string.rb
@@ -1,0 +1,15 @@
+require "rspec/expectations/version"
+
+RSpec::Matchers.define :match_string do |expected|
+  match do |actual|
+    actual.force_encoding("UTF-8")
+    @expected = Regexp.new(unescape_text(expected), Regexp::MULTILINE)
+    @actual   = sanitize_text(actual)
+
+    values_match? @expected, @actual
+  end
+
+  diffable
+
+  description { "string matches: #{description_of expected}" }
+end

--- a/features/support/step_helper.rb
+++ b/features/support/step_helper.rb
@@ -2,6 +2,7 @@
 
 require 'aruba'
 require 'aruba/cucumber'
+require_relative 'matchers/match_string'
 require 'yaml'
 
 # Aruba ------------------------------------------------

--- a/internal/authors/authors.go
+++ b/internal/authors/authors.go
@@ -23,6 +23,10 @@ func (a Author) CoauthorTag() string {
 	return fmt.Sprintf("Co-Authored-By: %s <%s>", a.Name, a.Email)
 }
 
+func (a Author) CoauthorTagBytes() []byte {
+	return []byte(a.CoauthorTag())
+}
+
 func (a Author) InitialsFromName() string {
 	//return name.split(' ').map(word => word[0].toLowerCase()).join('');
 	words := strings.Split(a.Name, " ")

--- a/internal/cmd/mob_init.go
+++ b/internal/cmd/mob_init.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/davidalpert/go-git-mob/internal/cmd/utils"
+	"github.com/davidalpert/go-git-mob/internal/revParse"
+	"github.com/spf13/cobra"
+	"os"
+	"path/filepath"
+)
+
+type MobInitOptions struct {
+	*utils.PrinterOptions
+	utils.IOStreams
+}
+
+func NewMobInitOptions(ioStreams utils.IOStreams) *MobInitOptions {
+	return &MobInitOptions{
+		IOStreams:      ioStreams,
+		PrinterOptions: utils.NewPrinterOptions().WithDefaultOutput("text"),
+	}
+}
+
+func NewCmdMobInit(ioStreams utils.IOStreams) *cobra.Command {
+	o := NewMobInitOptions(ioStreams)
+	var cmd = &cobra.Command{
+		Use:     "init",
+		Short:   "initializes git-mob for the current repo",
+		Aliases: []string{"i", "initialize"},
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(cmd, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			return o.Run()
+		},
+	}
+
+	o.PrinterOptions.AddPrinterFlags(cmd)
+
+	return cmd
+}
+
+// Complete the options
+func (o *MobInitOptions) Complete(cmd *cobra.Command, args []string) error {
+	return nil
+}
+
+// Validate the options
+func (o *MobInitOptions) Validate() error {
+	if !revParse.InsideWorkTree() {
+		return fmt.Errorf("the init command only works inside a git repository's working folder")
+	}
+
+	return o.PrinterOptions.Validate()
+}
+
+// Run the command
+func (o *MobInitOptions) Run() error {
+	f := filepath.Join("hooks", "prepare-commit-msg")
+	fileName := revParse.GitPath(f)
+	fileNameRel := revParse.GitPathRelativeToTopLevelDirectory(f)
+	fileContents := `#!/bin/sh
+
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+SHA1=$3
+
+set -e
+
+git mob prepare-commit-msg "$COMMIT_MSG_FILE" $COMMIT_SOURCE $SHA1
+`
+	if err := os.WriteFile(fileName, []byte(fileContents), 0755); err != nil {
+		return fmt.Errorf("writing git hook: %v", err)
+	}
+	return o.IOStreams.WriteOutput(fmt.Sprintf("initialized local git hook: '%s'\ngit-mob will now help prepare commit messages in this repo\n", fileNameRel), o.PrinterOptions)
+}

--- a/internal/cmd/mob_prepare_commit_msg.go
+++ b/internal/cmd/mob_prepare_commit_msg.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/davidalpert/go-git-mob/internal/cfg"
+	"github.com/davidalpert/go-git-mob/internal/cmd/utils"
+	"github.com/davidalpert/go-git-mob/internal/msg"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+type MobPrepareCommitMsgOptions struct {
+	*utils.PrinterOptions
+	utils.IOStreams
+
+	// 1-3 positional args provided by git
+	CommitMessageFile string
+	Source            msg.Source // optional
+	CommitObject      string     // optional (required when Source is CommitSource)
+
+	RawArgs []string
+}
+
+func NewMobPrepareCommitMsgOptions(ioStreams utils.IOStreams) *MobPrepareCommitMsgOptions {
+	return &MobPrepareCommitMsgOptions{
+		IOStreams:      ioStreams,
+		PrinterOptions: utils.NewPrinterOptions().WithDefaultOutput("text"),
+	}
+}
+
+func NewCmdMobPrepareCommitMsg(ioStreams utils.IOStreams) *cobra.Command {
+	o := NewMobPrepareCommitMsgOptions(ioStreams)
+	var cmd = &cobra.Command{
+		Use:     "prepare-commit-msg",
+		Short:   "edits a message file to include current co-authors",
+		Aliases: []string{},
+		Args:    cobra.RangeArgs(1, 3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(cmd, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			return o.Run()
+		},
+	}
+
+	o.PrinterOptions.AddPrinterFlags(cmd)
+
+	return cmd
+}
+
+// Complete the options
+func (o *MobPrepareCommitMsgOptions) Complete(cmd *cobra.Command, args []string) error {
+	o.CommitMessageFile = args[0]
+	if len(args) > 1 {
+		o.Source = msg.CommitMsgSourceFromString(args[1])
+	} else {
+		o.Source = msg.EmptySource
+	}
+	if len(args) > 2 {
+		o.CommitObject = args[2]
+	}
+	o.RawArgs = args
+	return nil
+}
+
+// Validate the options
+func (o *MobPrepareCommitMsgOptions) Validate() error {
+	if o.Source == msg.UnknownSource {
+		return fmt.Errorf("'%s' is not a recognized message source", o.RawArgs[1])
+	}
+	if o.Source == msg.CommitSource && o.CommitObject == "" {
+		return fmt.Errorf("must provide a commit SHA with a message source of '%s'", msg.CommitSource.String())
+	}
+	return o.PrinterOptions.Validate()
+}
+
+// Run the command
+func (o *MobPrepareCommitMsgOptions) Run() error {
+	fileBytes, err := os.ReadFile(o.CommitMessageFile)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("opening '%s': %v", o.CommitMessageFile, err)
+	}
+
+	aa, err := cfg.GetCoAuthors()
+	if err != nil {
+		return fmt.Errorf("reading co-authors: %v", err)
+	}
+
+	if len(aa) == 0 {
+		return nil // nothing to do
+	}
+
+	updated, err := msg.AppendCoauthorMarkup(aa, fileBytes)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(o.CommitMessageFile, updated, os.ModePerm)
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -72,6 +72,7 @@ A git plugin to help manage git coauthors.
 
 	// Register subcommands
 	rootCmd.AddCommand(NewCmdMob(ioStreams))
+	rootCmd.AddCommand(NewCmdMobPrepareCommitMsg(ioStreams))
 	rootCmd.AddCommand(NewCmdSolo(ioStreams))
 	rootCmd.AddCommand(NewCmdCoauthors(ioStreams))
 	rootCmd.AddCommand(NewCmdExplode(ioStreams))

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -72,6 +72,7 @@ A git plugin to help manage git coauthors.
 
 	// Register subcommands
 	rootCmd.AddCommand(NewCmdMob(ioStreams))
+	rootCmd.AddCommand(NewCmdMobInit(ioStreams))
 	rootCmd.AddCommand(NewCmdMobPrepareCommitMsg(ioStreams))
 	rootCmd.AddCommand(NewCmdSolo(ioStreams))
 	rootCmd.AddCommand(NewCmdCoauthors(ioStreams))

--- a/internal/cmd/utils/printers.go
+++ b/internal/cmd/utils/printers.go
@@ -106,7 +106,9 @@ var supportedListPrinterCategories = []string{}
 
 func (o *PrinterOptions) marshalObjectToString(v interface{}, formatCategory string) (string, string, error) {
 	output := ""
-	if formatCategory == "yaml" {
+	if formatCategory == "text" {
+		output = v.(string)
+	} else if formatCategory == "yaml" {
 		oB, _ := yaml.Marshal(v)
 		output = string(oB)
 	} else if formatCategory == "json" {

--- a/internal/msg/append_coauthor_markup.go
+++ b/internal/msg/append_coauthor_markup.go
@@ -1,0 +1,75 @@
+package msg
+
+import (
+	"bytes"
+	"github.com/davidalpert/go-git-mob/internal/authors"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var (
+	empty = []byte("")
+	space = []byte(" ")
+	nl    = []byte("\n")
+)
+
+// AppendCoauthorMarkup appends Co-Authored-By markup to a commit message
+func AppendCoauthorMarkup(newCoauthors []authors.Author, msgBytes []byte) ([]byte, error) {
+	re := regexp.MustCompile(`(?im)^co-authored-by: ([^<]+?)\s+<([^>]+)>`)
+	existingCoauthorTags := re.FindAllStringSubmatch(string(msgBytes), -1)
+	coauthorsByEmail := make(map[string]authors.Author, 0)
+	coauthorEmails := make([]string, 0)
+	for _, capture := range existingCoauthorTags {
+		a := authors.Author{
+			Name:  capture[1],
+			Email: capture[2],
+		}
+		if _, found := coauthorsByEmail[a.Email]; !found {
+			coauthorsByEmail[a.Email] = a
+			coauthorEmails = append(coauthorEmails, a.Email)
+		}
+	}
+	cleanedB := bytes.TrimSpace(re.ReplaceAll(msgBytes, empty))
+
+	// add in new ones
+	for _, a := range newCoauthors {
+		if _, found := coauthorsByEmail[a.Email]; !found {
+			coauthorsByEmail[a.Email] = a
+			coauthorEmails = append(coauthorEmails, a.Email)
+		}
+	}
+
+	sort.Strings(coauthorEmails)
+
+	coAuthorBytes := make([]byte, 0)
+	for _, e := range coauthorEmails {
+		coAuthorBytes = append(coAuthorBytes, bytes.Join([][]byte{
+			nl, coauthorsByEmail[e].CoauthorTagBytes(),
+		}, empty)...)
+	}
+	coauthorsB := bytes.TrimSpace(coAuthorBytes)
+
+	updated := make([]byte, 0)
+	if commentPos := strings.Index(string(cleanedB), "# "); commentPos > -1 {
+		gitMessage := bytes.TrimSpace(cleanedB[0:commentPos])
+		gitComments := cleanedB[commentPos:]
+		updated = append(updated, bytes.Join([][]byte{
+			gitMessage, nl,
+			nl,
+			coauthorsB, nl,
+			nl,
+			gitComments, nl,
+		}, empty)...)
+	} else if len(coauthorsB) == 0 {
+		return msgBytes, nil
+	} else {
+		updated = append(updated, bytes.Join([][]byte{
+			cleanedB, nl,
+			nl,
+			coauthorsB, nl,
+			nl,
+		}, empty)...)
+	}
+	return updated, nil
+}

--- a/internal/msg/append_coauthor_markup_test.go
+++ b/internal/msg/append_coauthor_markup_test.go
@@ -1,0 +1,167 @@
+package msg
+
+import (
+	"github.com/davidalpert/go-git-mob/internal/authors"
+	"reflect"
+	"testing"
+)
+
+func TestAppendCoauthorMarkup(t *testing.T) {
+	tests := []struct {
+		name        string
+		haveAuthors []authors.Author
+		haveMsg     string
+		wantMsg     string
+		wantErr     bool
+	}{
+		{
+			name:        "empty message empty coauthors",
+			haveMsg:     "",
+			haveAuthors: []authors.Author{},
+			wantMsg:     "",
+			wantErr:     false,
+		},
+		{
+			name:    "empty message one coauthor",
+			haveMsg: "",
+			haveAuthors: []authors.Author{
+				{
+					Name:  "Hoban Washburne",
+					Email: "wash@serenity.com",
+				},
+			},
+			wantMsg: `
+
+Co-Authored-By: Hoban Washburne <wash@serenity.com>
+
+`,
+			wantErr: false,
+		},
+		{
+			name:    "empty message two coauthors",
+			haveMsg: "",
+			haveAuthors: []authors.Author{
+				{
+					Name:  "Hoban Washburne",
+					Email: "wash@serenity.com",
+				},
+				{
+					Name:  "Zoe Washburne",
+					Email: "zoe@serenity.com",
+				},
+			},
+			wantMsg: `
+
+Co-Authored-By: Hoban Washburne <wash@serenity.com>
+Co-Authored-By: Zoe Washburne <zoe@serenity.com>
+
+`,
+			wantErr: false,
+		},
+		{
+			name: "message with comments, two coauthors",
+			haveMsg: `add something awesome
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch 23-feat-append-to-commit-message
+# Your branch is up to date with 'origin/23-feat-append-to-commit-message'.
+#
+`,
+			haveAuthors: []authors.Author{
+				{
+					Name:  "Hoban Washburne",
+					Email: "wash@serenity.com",
+				},
+				{
+					Name:  "Zoe Washburne",
+					Email: "zoe@serenity.com",
+				},
+			},
+			wantMsg: `add something awesome
+
+Co-Authored-By: Hoban Washburne <wash@serenity.com>
+Co-Authored-By: Zoe Washburne <zoe@serenity.com>
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch 23-feat-append-to-commit-message
+# Your branch is up to date with 'origin/23-feat-append-to-commit-message'.
+#
+`,
+			wantErr: false,
+		},
+		{
+			name:        "existing coauthors empty coauthors",
+			haveAuthors: []authors.Author{},
+			haveMsg: `
+
+Co-Authored-By: Hoban Washburne <wash@serenity.com>
+Co-Authored-By: Zoe Washburne <zoe@serenity.com>
+`,
+			wantMsg: `
+
+Co-Authored-By: Hoban Washburne <wash@serenity.com>
+Co-Authored-By: Zoe Washburne <zoe@serenity.com>
+
+`,
+			wantErr: false,
+		},
+		{
+			name: "existing coauthors one coauthor; existing authors preserved while new authors are added",
+			haveAuthors: []authors.Author{
+				{
+					Name:  "Zoe Washburne",
+					Email: "zoe@serenity.com",
+				},
+			},
+			haveMsg: `
+
+Co-Authored-By: Hoban Washburne <wash@serenity.com>
+`,
+			wantMsg: `
+
+Co-Authored-By: Hoban Washburne <wash@serenity.com>
+Co-Authored-By: Zoe Washburne <zoe@serenity.com>
+
+`,
+			wantErr: false,
+		},
+		{
+			name: "existing coauthors one duplicate coauthor; duplicates are removed",
+			haveAuthors: []authors.Author{
+				{
+					Name:  "Zoe Washburne",
+					Email: "zoe@serenity.com",
+				},
+			},
+			haveMsg: `
+
+Co-Authored-By: Hoban Washburne <wash@serenity.com>
+Co-Authored-By: Zoe Washburne <zoe@serenity.com>
+`,
+			wantMsg: `
+
+Co-Authored-By: Hoban Washburne <wash@serenity.com>
+Co-Authored-By: Zoe Washburne <zoe@serenity.com>
+
+`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := AppendCoauthorMarkup(tt.haveAuthors, []byte(tt.haveMsg))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AppendCoauthorMarkup() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			gotMsg := string(got)
+			if !reflect.DeepEqual(gotMsg, tt.wantMsg) {
+				t.Errorf("AppendCoauthorMarkup()\ngot = '%s'\nwant = '%s'", gotMsg, tt.wantMsg)
+			}
+		})
+	}
+}

--- a/internal/msg/source.go
+++ b/internal/msg/source.go
@@ -1,0 +1,50 @@
+package msg
+
+type Source int
+
+const (
+	// comments from: https://git-scm.com/docs/githooks#_prepare_commit_msg
+	UnknownSource  Source = iota
+	EmptySource           // commit: source not provided
+	MessageSource         // commit-with-message: if a -m or -F option was given
+	TemplateSource        // commit-with-template: if a -t option was given or the configuration option commit.template is set
+	MergeSource           // merge-commit: if the commit is a merge or a .git/MERGE_MSG file exists
+	SquashSource          // squash-commit: if a .git/SQUASH_MSG file exists
+	CommitSource          // amending: followed by a commit object name (if a -c, -C or --amend option was given)
+)
+
+func CommitMsgSourceFromString(s string) Source {
+	switch s {
+	case "":
+		return EmptySource
+	case "message":
+		return MessageSource
+	case "template":
+		return TemplateSource
+	case "merge":
+		return MergeSource
+	case "squash":
+		return SquashSource
+	case "commit":
+		return CommitSource
+	}
+	return UnknownSource
+}
+
+func (s Source) String() string {
+	switch s {
+	case EmptySource:
+		return ""
+	case MessageSource:
+		return "message"
+	case TemplateSource:
+		return "template"
+	case MergeSource:
+		return "merge"
+	case SquashSource:
+		return "squash"
+	case CommitSource:
+		return "commit"
+	}
+	return "unknown"
+}

--- a/internal/revParse/paths.go
+++ b/internal/revParse/paths.go
@@ -44,3 +44,7 @@ func TopLevelDirectory() string {
 func GitPath(rel ...string) string {
 	return path.Join(append([]string{TopLevelDirectory(), ".git"}, rel...)...)
 }
+
+func GitPathRelativeToTopLevelDirectory(rel ...string) string {
+	return path.Join(append([]string{".git"}, rel...)...)
+}


### PR DESCRIPTION
- test: ignore featues with an `@ignore` tag; allows us to draft features ahead of their implementation without failing a build
- feat: add a prepare-commit-msg subcommand; this will make the actual hook script trivial and allows easy running of the feature directly outside of the hook
- feat: allow format "text" by the format printers
- feat: initialize a local repo with a prepare-commit-msg script25)
- feat: append coauthor to a commit with the message flag

resolve https://github.com/davidalpert/go-git-mob/issues/23