### PR TITLE
Parity specs

### DIFF
--- a/features/git-mob/explode.feature
+++ b/features/git-mob/explode.feature
@@ -27,5 +27,6 @@ Feature: explode
     Then the output should contain:
       """
       Here are some suggestions for coauthors based on existing authors of this repository:
+
       git mob add-coauthor JD Jane Doe jane@example.com
       """

--- a/features/git-mob/logging.feature
+++ b/features/git-mob/logging.feature
@@ -25,7 +25,7 @@ Feature: logging support
   Scenario: commit with logging
     Given I cd to "example"
     And an empty file ".git/COMMIT_EDITMSG"
-    When I successfully run `git mob prepare-commit-msg .git/COMMIT_EDITMSG message`
+    When I successfully run `git mob hooks prepare-commit-msg .git/COMMIT_EDITMSG message`
     Then the file ".git/COMMIT_EDITMSG" should contain:
       """
 

--- a/features/git-mob/mob-init.feature
+++ b/features/git-mob/mob-init.feature
@@ -28,7 +28,7 @@ Feature: mob-init
 
       set -e
 
-      git mob prepare-commit-msg "$COMMIT_MSG_FILE" $COMMIT_SOURCE $SHA1
+      git mob hooks prepare-commit-msg "$COMMIT_MSG_FILE" $COMMIT_SOURCE $SHA1
       """
     And the output should contain:
       """

--- a/features/git-mob/mob-prepare-commit-msg.feature
+++ b/features/git-mob/mob-prepare-commit-msg.feature
@@ -16,7 +16,7 @@ Feature: mob prepare-commit-msg
 
   Scenario: one coauthor - message - empty message
     Given an empty file ".git/COMMIT_EDITMSG"
-    And I successfully run `git mob prepare-commit-msg .git/COMMIT_EDITMSG message`
+    And I successfully run `git mob hooks prepare-commit-msg .git/COMMIT_EDITMSG message`
     Then the file ".git/COMMIT_EDITMSG" should contain:
       """
 
@@ -35,7 +35,7 @@ Feature: mob prepare-commit-msg
       # Your branch is up to date with 'origin/23-feat-append-to-commit-message'.
       #
       """
-    And I successfully run `git mob prepare-commit-msg .git/COMMIT_EDITMSG message`
+    And I successfully run `git mob hooks prepare-commit-msg .git/COMMIT_EDITMSG message`
     Then the file ".git/COMMIT_EDITMSG" should contain:
       """
       Add something awesome

--- a/features/git-mob/mob.feature
+++ b/features/git-mob/mob.feature
@@ -39,7 +39,7 @@ Feature: mob
     When I run git mob `be`
     Then the output should contain:
     """
-    could not find coauthor with initials 'be'; run 'git mob --list' to see a list of available co-authors
+    author with initials 'be' not found; run 'git mob --list' to see a list of available co-authors
     """
 
   Scenario: start mob with two coauthors
@@ -79,5 +79,5 @@ Feature: mob
     When I run git mob `ad`
     Then the output should contain:
     """
-    could not find coauthor with initials 'ad'; run 'git mob --list' to see a list of available co-authors
+    author with initials 'ad' not found; run 'git mob --list' to see a list of available co-authors
     """

--- a/features/git-mob/parity/check-author.feature
+++ b/features/git-mob/parity/check-author.feature
@@ -1,0 +1,43 @@
+Feature: check-author.spec
+
+  Background:
+    Given I have installed go-git-mob into "local_bin" within the current directory
+    And I look for executables in "local_bin" within the current directory
+    Given a simple git repo at "example"
+
+  Scenario: does not print warning when config present
+    Given I cd to "example"
+    And I successfully run `git config --global user.name "Jane Doe"`
+    And I successfully run `git config --global user.email "jane@example.com"`
+    When I successfully run `git mob`
+    Then the stdout from "git mob" should contain:
+      """
+      Jane Doe <jane@example.com>
+      """
+
+  Scenario: prints warning and missing config when one argument is missing
+    Given I cd to "example"
+    And I successfully run `git config --global user.name "Jane Doe"`
+    And I run `git config --global --unset user.email`
+    When I run `git mob`
+    Then the exit status should be 1
+    And the stdout from "git mob" should contain:
+      """
+      warning: Missing information for the primary author. Set with:
+
+      $ git config --global user.email "jane@example.com"
+      """
+
+  Scenario: prints warning and missing config when both arguments are missing
+    Given I cd to "example"
+    And I run `git config --global --unset user.name`
+    And I run `git config --global --unset user.email`
+    When I run `git mob`
+    Then the exit status should be 1
+    And the stdout from "git mob" should contain:
+      """
+      warning: Missing information for the primary author. Set with:
+
+      $ git config --global user.name "Jane Doe"
+      $ git config --global user.email "jane@example.com"
+      """

--- a/features/git-mob/parity/git-add-coauthor.feature
+++ b/features/git-mob/parity/git-add-coauthor.feature
@@ -1,0 +1,93 @@
+@pending
+# issue #8 https://github.com/davidalpert/go-git-mob/issues/8
+Feature: git-add-coauthor.spec
+
+  Background:
+    Given I have installed go-git-mob into "local_bin" within the current directory
+    And I look for executables in "local_bin" within the current directory
+    And a file named "~/.git-coauthors" with:
+      """
+      {
+        "coauthors": {
+          "jd": {
+            "name": "Jane Doe",
+            "email": "jane@findmypast.com"
+          },
+          "fb": {
+            "name": "Frances Bar",
+            "email": "frances-bar@findmypast.com"
+          },
+          "ea": {
+            "name": "Elliot Alderson",
+            "email": "ealderson@findmypast.com"
+          }
+        }
+      }
+      """
+
+  Scenario: adds coauthor to coauthors file
+    When I successfully run `git add-coauthor tb "Barry Butterworth" barry@butterworth.org`
+    Then the file named "~/.git-coauthors" should include these coauthors:
+      """
+      {
+        "jd": {
+          "name": "Jane Doe",
+          "email": "jane@findmypast.com"
+        },
+        "fb": {
+          "name": "Frances Bar",
+          "email": "frances-bar@findmypast.com"
+        },
+        "ea": {
+          "name": "Elliot Alderson",
+          "email": "ealderson@findmypast.com"
+        },
+        "tb": {
+          "name": "Barry Butterworth",
+          "email": "barry@butterworth.org"
+        }
+      }
+      """
+
+  Scenario: does not add coauthor to coauthors file if email invalid
+    When I run `git add-coauthor tb "Barry Butterworth" barry.org`
+    Then the exit status should be 1
+    And the file named "~/.git-coauthors" should not include these coauthors:
+      """
+      {
+        "tb": {
+          "name": "Barry Butterworth",
+          "email": "barry.org"
+        }
+      }
+      """
+
+  Scenario: does not add coauthor to coauthors file if wrong amount of parameters
+    When I run `git add-coauthor tb "Barry Butterworth"`
+    Then the exit status should be 1
+    And the file named "~/.git-coauthors" should not include these coauthors:
+      """
+      {
+        "tb": {
+          "name": "Barry Butterworth"
+        }
+      }
+      """
+
+  Scenario: does not add coauthor to coauthors file if key already exists
+    When I run `git add-coauthor ea "Emily Anderson" "emily@anderson.org"`
+    Then the exit status should be 1
+    And the file named "~/.git-coauthors" should not include these coauthors:
+      """
+      {
+        "ea": {
+          "name": "Emily Anderson",
+          "email": "emily@anderson.org"
+        }
+      }
+      """
+
+  Scenario: -h prints help
+    When I successfully run `git add-coauthor -h`
+    Then the output should contain "Usage"
+    And the output should contain "Flags"

--- a/features/git-mob/parity/git-delete-coauthor.feature
+++ b/features/git-mob/parity/git-delete-coauthor.feature
@@ -1,0 +1,64 @@
+@pending
+# issue #9 https://github.com/davidalpert/go-git-mob/issues/9
+Feature: git-delete-coauthor.spec
+
+  Background:
+    Given I have installed go-git-mob into "local_bin" within the current directory
+    And I look for executables in "local_bin" within the current directory
+    And a file named "~/.git-coauthors" with:
+      """
+      {
+        "coauthors": {
+          "jd": {
+            "name": "Jane Doe",
+            "email": "jane@findmypast.com"
+          },
+          "fb": {
+            "name": "Frances Bar",
+            "email": "frances-bar@findmypast.com"
+          },
+          "ea": {
+            "name": "Elliot Alderson",
+            "email": "ealderson@findmypast.com"
+          }
+        }
+      }
+      """
+
+  Scenario: deletes coauthor from coauthors file
+    When I successfully run `git delete-coauthor ea`
+    Then the file named "~/.git-coauthors" should not include these coauthors:
+      """
+      {
+        "ea": {
+          "name": "Elliot Alderson",
+          "email": "ealderson@findmypast.com"
+        }
+      }
+      """
+
+  Scenario: does nothing if initial are not a key in coauthors file
+    When I run `git delete-coauthor bb`
+    Then the exit status should be 1
+    And the file named "~/.git-coauthors" should include these coauthors:
+      """
+      {
+        "jd": {
+          "name": "Jane Doe",
+          "email": "jane@findmypast.com"
+        },
+        "fb": {
+          "name": "Frances Bar",
+          "email": "frances-bar@findmypast.com"
+        },
+        "ea": {
+          "name": "Elliot Alderson",
+          "email": "ealderson@findmypast.com"
+        }
+      }
+      """
+
+  Scenario: -h prints help
+    When I successfully run `git delete-coauthor -h`
+    Then the output should contain "Usage"
+    And the output should contain "Flags"

--- a/features/git-mob/parity/git-edit-coauthor.feature
+++ b/features/git-mob/parity/git-edit-coauthor.feature
@@ -1,0 +1,151 @@
+@pending
+# issue #10 https://github.com/davidalpert/go-git-mob/issues/10
+Feature: git-edit-coauthor.spec
+
+  Background:
+    Given I have installed go-git-mob into "local_bin" within the current directory
+    And I look for executables in "local_bin" within the current directory
+    And a file named "~/.git-coauthors" with:
+      """
+      {
+        "coauthors": {
+          "jd": {
+            "name": "Jane Doe",
+            "email": "jane@findmypast.com"
+          },
+          "fb": {
+            "name": "Frances Bar",
+            "email": "frances-bar@findmypast.com"
+          },
+          "ea": {
+            "name": "Elliot Alderson",
+            "email": "ealderson@findmypast.com"
+          }
+        }
+      }
+      """
+
+  Scenario: edits coauthors name in coauthors file
+    When I successfully run `git edit-coauthor ea --name="emily aldershot"`
+    Then the file named "~/.git-coauthors" should include these coauthors:
+      """
+      {
+        "jd": {
+          "name": "Jane Doe",
+          "email": "jane@findmypast.com"
+        },
+        "fb": {
+          "name": "Frances Bar",
+          "email": "frances-bar@findmypast.com"
+        },
+        "ea": {
+          "name": "emily aldershot",
+          "email": "ealderson@findmypast.com"
+        }
+      }
+      """
+
+  Scenario: edits coauthors email in coauthors file
+    When I successfully run `git edit-coauthor ea --email="emily@aldershot.com"`
+    Then the file named "~/.git-coauthors" should include these coauthors:
+      """
+      {
+        "jd": {
+          "name": "Jane Doe",
+          "email": "jane@findmypast.com"
+        },
+        "fb": {
+          "name": "Frances Bar",
+          "email": "frances-bar@findmypast.com"
+        },
+        "ea": {
+          "name": "Elliot Alderson",
+          "email": "emily@aldershot.com"
+        }
+      }
+      """
+
+  Scenario: edits coauthors name and email in coauthors file
+    When I successfully run `git edit-coauthor ea --email="emily@aldershot.com" --name="emily aldershot"`
+    Then the file named "~/.git-coauthors" should include these coauthors:
+      """
+      {
+        "jd": {
+          "name": "Jane Doe",
+          "email": "jane@findmypast.com"
+        },
+        "fb": {
+          "name": "Frances Bar",
+          "email": "frances-bar@findmypast.com"
+        },
+        "ea": {
+          "name": "emily aldershot",
+          "email": "emily@aldershot.com"
+        }
+      }
+      """
+
+  Scenario: does not update a random key input
+    When I run `git edit-coauthor ea --ship="serenity"`
+    Then the exit status should be 1
+    Then the file named "~/.git-coauthors" should include these coauthors:
+      """
+      {
+        "jd": {
+          "name": "Jane Doe",
+          "email": "jane@findmypast.com"
+        },
+        "fb": {
+          "name": "Frances Bar",
+          "email": "frances-bar@findmypast.com"
+        },
+        "ea": {
+          "name": "Elliot Alderson",
+          "email": "ealderson@findmypast.com"
+        }
+      }
+      """
+    And the file named "~/.git-coauthors" should not include these coauthors:
+      """
+      {
+        "ea": {
+          "name": "Elliot Alderson",
+          "email": "emily@aldershot.com",
+          "ship": "serenity"
+        }
+      }
+      """
+
+  Scenario: does not update if author does not already exist'
+    When I run `git edit-coauthor bb --name="barry butterworth"`
+    Then the exit status should be 1
+    Then the file named "~/.git-coauthors" should include these coauthors:
+      """
+      {
+        "jd": {
+          "name": "Jane Doe",
+          "email": "jane@findmypast.com"
+        },
+        "fb": {
+          "name": "Frances Bar",
+          "email": "frances-bar@findmypast.com"
+        },
+        "ea": {
+          "name": "Elliot Alderson",
+          "email": "ealderson@findmypast.com"
+        }
+      }
+      """
+    And the file named "~/.git-coauthors" should not include these coauthors:
+      """
+      {
+        "bb": {
+          "name": "barry butterworth"
+        }
+      }
+      """
+
+  Scenario: -h prints help
+    When I successfully run `git edit-coauthor -h`
+    Then the output should contain "Usage"
+    And the output should contain "Flags"

--- a/features/git-mob/parity/git-mob.feature
+++ b/features/git-mob/parity/git-mob.feature
@@ -95,5 +95,15 @@ Feature: git-mob.spec
       """
       author with initials 'zz' not found
       """
+
+  Scenario: overwrites old mob when setting a new mob
+    Given I successfully run `git mob ad`
+    When I successfully run `git mob bd`
+    Then the output should contain:
+      """
+      Jane Doe <jane@example.com>
+      Bob Doe <bob@example.com>
+      """
+
 # @wip
 # @announce-stdout

--- a/features/git-mob/parity/git-mob.feature
+++ b/features/git-mob/parity/git-mob.feature
@@ -89,5 +89,11 @@ Feature: git-mob.spec
       Bob Doe <bob@example.com>
       """
 
+  Scenario: errors when co-author initials not found
+    When I run `git mob zz`
+    Then the output should contain:
+      """
+      author with initials 'zz' not found
+      """
 # @wip
 # @announce-stdout

--- a/features/git-mob/parity/git-mob.feature
+++ b/features/git-mob/parity/git-mob.feature
@@ -141,5 +141,17 @@ Feature: git-mob.spec
       Co-authored-by: Bob Doe <bob@example.com>
       """
 
+  Scenario: appends co-authors to a new commit template
+    Given a simple git repo at "example"
+    And I cd to "example"
+    And a file named ".git/.gitmessage" does not exist
+    When I successfully run `git mob ad bd`
+    And a file named ".git/.gitmessage" should contain:
+      """
+
+      Co-authored-by: Amy Doe <amy@example.com>
+      Co-authored-by: Bob Doe <bob@example.com>
+      """
+
 # @wip
 # @announce-stdout

--- a/features/git-mob/parity/git-mob.feature
+++ b/features/git-mob/parity/git-mob.feature
@@ -50,5 +50,12 @@ Feature: git-mob.spec
       bd Bob Doe bob@example.com
       """
 
+  Scenario: prints only primary author when there is no mob
+    When I successfully run `git mob`
+    Then the output should contain:
+      """
+      Jane Doe <jane@example.com>
+      """
+
 # @wip
 # @announce-stdout

--- a/features/git-mob/parity/git-mob.feature
+++ b/features/git-mob/parity/git-mob.feature
@@ -75,5 +75,19 @@ Feature: git-mob.spec
       Amy Doe <amy@example.com>
       """
 
+  @pending
+  # issue #7 https://github.com/davidalpert/go-git-mob/issues/7
+  # NOTE: the -o flag is already in use for --output; will need
+  #       to either pick a different shortcut for the override
+  #       command or disable output formatting; I would prefer
+  #       to use a different flag peraps even --o
+  Scenario: sets mob and override coauthor
+    When I successfully run `git mob -o ad bd`
+    Then the output should contain:
+      """
+      Amy Doe <amy@example.com>
+      Bob Doe <bob@example.com>
+      """
+
 # @wip
 # @announce-stdout

--- a/features/git-mob/parity/git-mob.feature
+++ b/features/git-mob/parity/git-mob.feature
@@ -5,6 +5,21 @@ Feature: git-mob.spec
     And I look for executables in "local_bin" within the current directory
     And I successfully run `git config --global user.name "Jane Doe"`
     And I successfully run `git config --global user.email "jane@example.com"`
+    And a file named "~/.git-coauthors" with:
+      """
+      {
+        "coauthors": {
+          "ad": {
+            "name": "Amy Doe",
+            "email": "amy@example.com"
+          },
+          "bd": {
+            "name": "Bob Doe",
+            "email": "bob@example.com"
+          }
+        }
+      }
+      """
 
   Scenario: -h prints help
     When I successfully run `git mob -h`
@@ -28,21 +43,6 @@ Feature: git-mob.spec
     Then the output should match /\d.\d.\d/
 
   Scenario: --list prints a list of avaialable co-authors
-    Given a file named "~/.git-coauthors" with:
-      """
-      {
-        "coauthors": {
-          "ad": {
-            "name": "Amy Doe",
-            "email": "amy@example.com"
-          },
-          "bd": {
-            "name": "Bob Doe",
-            "email": "bob@example.com"
-          }
-        }
-      }
-      """
     When I successfully run `git mob --list`
     Then the output should contain:
       """
@@ -58,22 +58,7 @@ Feature: git-mob.spec
       """
 
   Scenario: prints current mob
-    Given a file named "~/.git-coauthors" with:
-      """
-      {
-        "coauthors": {
-          "ad": {
-            "name": "Amy Doe",
-            "email": "amy@example.com"
-          },
-          "bd": {
-            "name": "Bob Doe",
-            "email": "bob@example.com"
-          }
-        }
-      }
-      """
-    And I successfully run `git mob ad bd`
+    Given I successfully run `git mob ad bd`
     When I successfully run `git mob`
     Then the output should contain:
       """

--- a/features/git-mob/parity/git-mob.feature
+++ b/features/git-mob/parity/git-mob.feature
@@ -12,3 +12,10 @@ Feature: git-mob.spec
     And the output should contain "Flags"
     And the output should contain "Examples"
 
+  #@announce-stderr
+  @not-windows
+  Scenario: --help prints help
+    # --help is intercepted by the git plugin launcher which returns a 404 (help not found)
+    When I run `git mob --help`
+    Then the output should contain "No manual entry for git-mob"
+

--- a/features/git-mob/parity/git-mob.feature
+++ b/features/git-mob/parity/git-mob.feature
@@ -121,5 +121,25 @@ Feature: git-mob.spec
       Co-authored-by: Bob Doe <bob@example.com>
       """
 
+  Scenario: appends co-authors to an existing commit template
+    Given a simple git repo at "example"
+    And I cd to "example"
+    And a file named ".git/.gitmessage" with:
+      """
+      A commit title
+
+      A commit body that goes into more detail.
+      """
+    When I successfully run `git mob ad bd`
+    And a file named ".git/.gitmessage" should contain:
+      """
+      A commit title
+
+      A commit body that goes into more detail.
+
+      Co-authored-by: Amy Doe <amy@example.com>
+      Co-authored-by: Bob Doe <bob@example.com>
+      """
+
 # @wip
 # @announce-stdout

--- a/features/git-mob/parity/git-mob.feature
+++ b/features/git-mob/parity/git-mob.feature
@@ -27,5 +27,28 @@ Feature: git-mob.spec
     When I successfully run `git mob --version`
     Then the output should match /\d.\d.\d/
 
-  # @wip
-  # @announce-stdout
+  Scenario: --list prints a list of avaialable co-authors
+    Given a file named "~/.git-coauthors" with:
+      """
+      {
+        "coauthors": {
+          "ad": {
+            "name": "Amy Doe",
+            "email": "amy@example.com"
+          },
+          "bd": {
+            "name": "Bob Doe",
+            "email": "bob@example.com"
+          }
+        }
+      }
+      """
+    When I successfully run `git mob --list`
+    Then the output should contain:
+      """
+      ad Amy Doe amy@example.com
+      bd Bob Doe bob@example.com
+      """
+
+# @wip
+# @announce-stdout

--- a/features/git-mob/parity/git-mob.feature
+++ b/features/git-mob/parity/git-mob.feature
@@ -20,9 +20,10 @@ Feature: git-mob.spec
         }
       }
       """
+    Given a simple git repo at "example"
 
   Scenario: -h prints help
-    When I successfully run `git mob -h`
+    Given I successfully run `git mob -h`
     Then the output should contain "Usage"
     And the output should contain "Flags"
     And the output should contain "Examples"
@@ -58,7 +59,8 @@ Feature: git-mob.spec
       """
 
   Scenario: prints current mob
-    Given I successfully run `git mob ad bd`
+    Given I cd to "example"
+    And I successfully run `git mob ad bd`
     When I successfully run `git mob`
     Then the output should contain:
       """
@@ -68,6 +70,7 @@ Feature: git-mob.spec
       """
 
   Scenario: sets mob when co-author initials found
+    Given I cd to "example"
     When I successfully run `git mob ad`
     Then the output should contain:
       """
@@ -82,6 +85,7 @@ Feature: git-mob.spec
   #       command or disable output formatting; I would prefer
   #       to use a different flag peraps even --o
   Scenario: sets mob and override coauthor
+    Given I cd to "example"
     When I successfully run `git mob -o ad bd`
     Then the output should contain:
       """
@@ -90,6 +94,7 @@ Feature: git-mob.spec
       """
 
   Scenario: errors when co-author initials not found
+    Given I cd to "example"
     When I run `git mob zz`
     Then the output should contain:
       """

--- a/features/git-mob/parity/git-mob.feature
+++ b/features/git-mob/parity/git-mob.feature
@@ -97,12 +97,28 @@ Feature: git-mob.spec
       """
 
   Scenario: overwrites old mob when setting a new mob
-    Given I successfully run `git mob ad`
+    Given a simple git repo at "example"
+    And I cd to "example"
+    And a file named ".git/.gitmessage" with:
+      """
+      A commit title
+
+      A commit body that goes into more detail.
+      """
+    And I successfully run `git mob ad`
     When I successfully run `git mob bd`
     Then the output should contain:
       """
       Jane Doe <jane@example.com>
       Bob Doe <bob@example.com>
+      """
+    And a file named ".git/.gitmessage" should contain:
+      """
+      A commit title
+
+      A commit body that goes into more detail.
+
+      Co-authored-by: Bob Doe <bob@example.com>
       """
 
 # @wip

--- a/features/git-mob/parity/git-mob.feature
+++ b/features/git-mob/parity/git-mob.feature
@@ -19,3 +19,9 @@ Feature: git-mob.spec
     When I run `git mob --help`
     Then the output should contain "No manual entry for git-mob"
 
+  Scenario: -v prints version
+    When I successfully run `git mob -v`
+    Then the output should match /\d.\d.\d/
+
+  # @wip
+  # @announce-stdout

--- a/features/git-mob/parity/git-mob.feature
+++ b/features/git-mob/parity/git-mob.feature
@@ -23,5 +23,9 @@ Feature: git-mob.spec
     When I successfully run `git mob -v`
     Then the output should match /\d.\d.\d/
 
+  Scenario: --version prints version
+    When I successfully run `git mob --version`
+    Then the output should match /\d.\d.\d/
+
   # @wip
   # @announce-stdout

--- a/features/git-mob/parity/git-mob.feature
+++ b/features/git-mob/parity/git-mob.feature
@@ -57,5 +57,30 @@ Feature: git-mob.spec
       Jane Doe <jane@example.com>
       """
 
+  Scenario: prints current mob
+    Given a file named "~/.git-coauthors" with:
+      """
+      {
+        "coauthors": {
+          "ad": {
+            "name": "Amy Doe",
+            "email": "amy@example.com"
+          },
+          "bd": {
+            "name": "Bob Doe",
+            "email": "bob@example.com"
+          }
+        }
+      }
+      """
+    And I successfully run `git mob ad bd`
+    When I successfully run `git mob`
+    Then the output should contain:
+      """
+      Jane Doe <jane@example.com>
+      Amy Doe <amy@example.com>
+      Bob Doe <bob@example.com>
+      """
+
 # @wip
 # @announce-stdout

--- a/features/git-mob/parity/git-mob.feature
+++ b/features/git-mob/parity/git-mob.feature
@@ -67,5 +67,13 @@ Feature: git-mob.spec
       Bob Doe <bob@example.com>
       """
 
+  Scenario: sets mob when co-author initials found
+    When I successfully run `git mob ad`
+    Then the output should contain:
+      """
+      Jane Doe <jane@example.com>
+      Amy Doe <amy@example.com>
+      """
+
 # @wip
 # @announce-stdout

--- a/features/git-mob/parity/git-mob.feature
+++ b/features/git-mob/parity/git-mob.feature
@@ -1,0 +1,14 @@
+Feature: git-mob.spec
+
+  Background:
+    Given I have installed go-git-mob into "local_bin" within the current directory
+    And I look for executables in "local_bin" within the current directory
+    And I successfully run `git config --global user.name "Jane Doe"`
+    And I successfully run `git config --global user.email "jane@example.com"`
+
+  Scenario: -h prints help
+    When I successfully run `git mob -h`
+    Then the output should contain "Usage"
+    And the output should contain "Flags"
+    And the output should contain "Examples"
+

--- a/features/git-mob/parity/git-mob.feature
+++ b/features/git-mob/parity/git-mob.feature
@@ -158,5 +158,15 @@ Feature: git-mob.spec
       Co-authored-by: Bob Doe <bob@example.com>
       """
 
+  @pending
+  # allow running some mob commands outside a working tree
+  # so that the mob follows across project folders
+  Scenario: warns when used outside of a git repo
+    # also hard to test not being in a working tree
+    # because by default the aruba test folder is
+    # still "inside" the core project's working tree
+    When I run `git mob`
+    Then the exit status should be 1
+
 # @wip
 # @announce-stdout

--- a/features/git-mob/parity/git-solo.feature
+++ b/features/git-mob/parity/git-solo.feature
@@ -1,0 +1,39 @@
+Feature: git-solo.spec
+
+  Background:
+    Given I have installed go-git-mob into "local_bin" within the current directory
+    And I look for executables in "local_bin" within the current directory
+    And I successfully run `git config --global user.name "Jane Doe"`
+    And I successfully run `git config --global user.email "jane@example.com"`
+    And a file named "~/.git-coauthors" with:
+      """
+      {
+        "coauthors": {
+          "ad": {
+            "name": "Amy Doe",
+            "email": "amy@example.com"
+          },
+          "bd": {
+            "name": "Bob Doe",
+            "email": "bob@example.com"
+          }
+        }
+      }
+      """
+    Given a simple git repo at "example"
+
+  Scenario: sets the current mob to the primary author
+    Given I cd to "example"
+    And I successfully run `git mob ad bd`
+    When I successfully run `git solo`
+    Then the stdout from "git solo" should contain:
+      """
+      Jane Doe <jane@example.com>
+      """
+    And the stdout from "git solo" should not contain:
+      """
+      Bob Doe <bob@example.com>
+      """
+
+# @wip
+# @announce-stdout

--- a/features/git-mob/parity/git-solo.feature
+++ b/features/git-mob/parity/git-solo.feature
@@ -35,5 +35,22 @@ Feature: git-solo.spec
       Bob Doe <bob@example.com>
       """
 
+  Scenario: removes co-authors from commit template
+    Given I cd to "example"
+    And a file named ".git/.gitmessage" with:
+      """
+      A commit title
+
+      A commit body that goes into more detail.
+      """
+    And I successfully run `git mob ad bd`
+    When I successfully run `git solo`
+    Then a file named ".git/.gitmessage" should contain:
+      """
+      A commit title
+
+      A commit body that goes into more detail.
+      """
+
 # @wip
 # @announce-stdout

--- a/features/git-mob/parity/git-solo.feature
+++ b/features/git-mob/parity/git-solo.feature
@@ -52,5 +52,18 @@ Feature: git-solo.spec
       A commit body that goes into more detail.
       """
 
+  Scenario: ignores positional arguments
+    Given I cd to "example"
+    And I successfully run `git mob ad bd`
+    When I successfully run `git solo yolo`
+    Then the stdout from "git solo yolo" should contain:
+      """
+      Jane Doe <jane@example.com>
+      """
+    And the stdout from "git solo yolo" should not contain:
+      """
+      Bob Doe <bob@example.com>
+      """
+
 # @wip
 # @announce-stdout

--- a/features/git-mob/parity/git-solo.feature
+++ b/features/git-mob/parity/git-solo.feature
@@ -65,5 +65,12 @@ Feature: git-solo.spec
       Bob Doe <bob@example.com>
       """
 
-# @wip
-# @announce-stdout
+  @pending
+  # allow running some mob commands outside a working tree
+  # so that the mob follows across project folders
+  Scenario: warns when used outside of a git repo
+    # also hard to test not being in a working tree
+    # because by default the aruba test folder is
+    # still "inside" the core project's working tree
+    When I run `git mob`
+    Then the exit status should be 1

--- a/features/git-mob/parity/git-suggest-coauthors.feature
+++ b/features/git-mob/parity/git-suggest-coauthors.feature
@@ -1,0 +1,42 @@
+Feature: git-suggest-coauthors.spec
+
+  Background:
+    Given I have installed go-git-mob into "local_bin" within the current directory
+    And I look for executables in "local_bin" within the current directory
+    And I successfully run `git config --global user.name "Jane Doe"`
+    And I successfully run `git config --global user.email "jane@example.com"`
+
+  Scenario: suggests potential coauthors
+    Given a simple git repo at "example" with the following empty commits:
+      | Name    | Email              | Commit_Message     |
+      | Amy Doe | amy@findmypast.com | Amy's empty commit |
+      | Bob Doe | bob@findmypast.com | Bob's empty commit |
+    When I cd to "example"
+    And I successfully run `git suggest-coauthors`
+    Then the stdout from "git suggest-coauthors" should contain:
+      """
+      Here are some suggestions for coauthors based on existing authors of this repository:
+
+      git mob add-coauthor AD Amy Doe amy@findmypast.com
+      git mob add-coauthor BD Bob Doe bob@findmypast.com
+
+      Paste any line above.
+      """
+
+  Scenario: shows error when there are no commits found
+    Given a simple git repo at "example" with the following empty commits:
+      | Name    | Email              | Commit_Message     |
+    When I cd to "example"
+    And I run `git suggest-coauthors`
+    Then the exit status should be 1
+    Then the stdout from "git suggest-coauthors" should contain:
+      """
+      unable to find existing authors
+      """
+
+  Scenario: -h prints help
+    Given a simple git repo at "example"
+    When I cd to "example"
+    And I successfully run `git suggest-coauthors -h`
+    Then the output should contain "Usage"
+    And the output should contain "Flags"

--- a/features/git-mob/suggest-coauthors.feature
+++ b/features/git-mob/suggest-coauthors.feature
@@ -30,9 +30,12 @@ Feature: Suggest co-authors from commit history
     Then the output should contain:
     """
     Here are some suggestions for coauthors based on existing authors of this repository:
+
     git mob add-coauthor AD Amy Doe amy@findmypast.com
     git mob add-coauthor BD Bob Doe bob@findmypast.com
     git mob add-coauthor JD Jane Doe jane@example.com
+    
+    Paste any line above.
     """
 
   Scenario: suggest co-authors as a table

--- a/features/git-mob/suggest-coauthors.feature
+++ b/features/git-mob/suggest-coauthors.feature
@@ -19,9 +19,10 @@ Feature: Suggest co-authors from commit history
     }
     """
     And a simple git repo at "example" with the following empty commits:
-      | Name    | Email              | Commit_Message     |
-      | Amy Doe | amy@findmypast.com | Amy's empty commit |
-      | Bob Doe | bob@findmypast.com | Bob's empty commit |
+      | Name     | Email              | Commit_Message       |
+      | Amy Doe  | amy@findmypast.com | Amy's empty commit   |
+      | Bob Doe  | bob@findmypast.com | Bob's empty commit   |
+      | Jane Doe | jane@example.com   | initial empty commit |
 
   Scenario: suggest co-authors as text
     Given I cd to "example"

--- a/features/step_definitions/co-author_steps.rb
+++ b/features/step_definitions/co-author_steps.rb
@@ -1,0 +1,18 @@
+# Then('the file named {string} should include these coauthors:')
+Then(/^(?:a|the) file(?: named)? "([^"]*)" should (not )?include these coauthors:$/) do |file, negated, doc_string|
+  expanded_path = expand_path(file)
+
+  expect(file).to be_an_existing_file
+
+  @actual   = JSON.parse(File.read(expanded_path).chomp)
+  @expected = JSON.parse(doc_string.chomp)
+
+  # puts "ACTUAL\n#{@actual}\n"
+  # puts "EXPECTED\n#{@expected}\n"
+
+  if negated
+    expect(@actual["coauthors"]).to_not include(@expected)
+  else
+    expect(@actual["coauthors"]).to include(@expected)
+  end
+end

--- a/features/step_definitions/installation_steps.rb
+++ b/features/step_definitions/installation_steps.rb
@@ -21,5 +21,6 @@ Given('I have installed go-git-mob into {string} within the current directory') 
 
   create_directory(path)
   FileUtils.cp(exe, File.join(aruba.current_directory, path))
+  run_command_and_stop("git mob explode", fail_on_error: true)
   run_command_and_stop("ls -la #{path}", fail_on_error: true)
 end

--- a/features/step_definitions/repo_steps.rb
+++ b/features/step_definitions/repo_steps.rb
@@ -31,16 +31,14 @@ Given('a simple git repo at {string} with the following empty commits:') do |pat
   cd(path) do
     run_command_and_stop('git config --global init.defaultBranch main', fail_on_error: true)
     run_command_and_stop(sanitize_text("git init ."), fail_on_error: true)
-    run_command_and_stop('git commit --allow-empty -m "initial, empty root commit"', fail_on_error: true)
 
-    data = table.raw
-    data.drop(1).reverse.each do |cols|
+    data = table.raw.drop(1) # first row is headings
+    data.reverse.each do |cols|
        run_command_and_stop("git config user.name \"#{cols[0]}\"", fail_on_error: true)
        run_command_and_stop("git config user.email \"#{cols[1]}\"", fail_on_error: true)
        run_command_and_stop("git commit --allow-empty -m \"#{cols[2]}\"", fail_on_error: true)
+       run_command_and_stop('git config --remove-section user', fail_on_error: true)
     end
-
-    run_command_and_stop('git config --remove-section user', fail_on_error: true)
   end
 end
 

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -17,3 +17,7 @@ end
 Before('@not-windows') do
   pending if GitMob::OS.windows?
 end
+
+Before('@pending') do
+  pending
+end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,3 +1,5 @@
+require_relative 'os_helper'
+
 Before do
 end
 
@@ -6,4 +8,12 @@ end
 
 Before('@announce-git-log') do
   aruba.announcer.activate :git_log
+end
+
+Before('@windows-only') do
+  pending unless GitMob::OS.windows?
+end
+
+Before('@not-windows') do
+  pending if GitMob::OS.windows?
 end

--- a/features/support/os_helper.rb
+++ b/features/support/os_helper.rb
@@ -1,0 +1,30 @@
+module GitMob
+  # syntax helpers for OS platform detection
+  # adapted from: https://stackoverflow.com/a/171011/8997
+  module OS
+    def OS.windows?
+      (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+    end
+
+    def OS.mac?
+      (/darwin/ =~ RUBY_PLATFORM) != nil
+    end
+
+    def OS.unix?
+      !OS.windows?
+    end
+
+    def OS.linux?
+      OS.unix? and not OS.mac?
+    end
+
+    def OS.jruby?
+      RUBY_ENGINE == 'jruby'
+    end
+  end
+end
+
+# rubocop:disable Style/MixinUsage
+# this extend is at the global scope deliberately, to make these helpers available in step definitions
+include GitMob::OS
+# rubocop:enable Style/MixinUsage

--- a/internal/cfg/config.go
+++ b/internal/cfg/config.go
@@ -167,14 +167,25 @@ func AddCoAuthors(aa ...authors.Author) error {
 
 // GetUser builds an authors.Author from the current configured user
 func GetUser() (*authors.Author, error) {
-	c, err := config.LoadConfig(config.GlobalScope)
-	if err != nil {
-		return nil, err
+	errMsg := "warning: Missing information for the primary author. Set with:\n"
+	name, nameErr := silentRun("git", "config", "user.name")
+	email, emailErr := silentRun("git", "config", "user.email")
+
+	if nameErr != nil {
+		errMsg = errMsg + "\n$ git config --global user.name \"Jane Doe\""
+	}
+
+	if emailErr != nil {
+		errMsg = errMsg + "\n$ git config --global user.email \"jane@example.com\""
+	}
+
+	if nameErr != nil || emailErr != nil {
+		return nil, fmt.Errorf(errMsg)
 	}
 
 	return &authors.Author{
-		Name:  c.User.Name,
-		Email: c.User.Email,
+		Name:  name,
+		Email: email,
 	}, nil
 }
 

--- a/internal/cmd/coauthors_suggest.go
+++ b/internal/cmd/coauthors_suggest.go
@@ -62,8 +62,8 @@ func (o *CoauthorsSuggestOptions) Validate() error {
 // Run the command
 func (o *CoauthorsSuggestOptions) Run() error {
 	aa, err := cfg.ShortLogAuthorSummary()
-	if err != nil {
-		return err
+	if err != nil || len(aa) == 0 {
+		return fmt.Errorf("unable to find existing authors in this repository")
 	}
 
 	initials := make([]string, len(aa))
@@ -77,11 +77,12 @@ func (o *CoauthorsSuggestOptions) Run() error {
 
 	if o.FormatCategory() == "text" {
 		if len(initials) > 0 {
-			fmt.Println("Here are some suggestions for coauthors based on existing authors of this repository:")
+			fmt.Printf("Here are some suggestions for coauthors based on existing authors of this repository:\n\n")
 			for _, ii := range initials {
 				a := aa[ii]
 				fmt.Printf("git mob add-coauthor %s %s %s\n", ii, a.Name, a.Email)
 			}
+			fmt.Println("\nPaste any line above.")
 		}
 		return nil
 	}

--- a/internal/cmd/explode.go
+++ b/internal/cmd/explode.go
@@ -65,7 +65,7 @@ func (o *ExplodeOptions) Run() error {
 		p := fmt.Sprintf("%s", path.Join(eDir, plugin))
 		c := fmt.Sprintf(`
 #!/bin/sh
-%s
+%s "$@"
 `, cmd)
 
 		fmt.Println("writing:", p)

--- a/internal/cmd/implode.go
+++ b/internal/cmd/implode.go
@@ -24,7 +24,7 @@ func NewCmdImplode(ioStreams utils.IOStreams) *cobra.Command {
 	o := NewImplodeOptions(ioStreams)
 	var cmd = &cobra.Command{
 		Use:     "implode",
-		Short:   "removes helper git plugin scripts",
+		Short:   "uninstall git-mob (removes helper git plugin scripts and deletes the git-mob binary)",
 		Aliases: []string{"uninstall"},
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/mob.go
+++ b/internal/cmd/mob.go
@@ -87,12 +87,8 @@ func (o *MobOptions) Complete(cmd *cobra.Command, args []string) error {
 
 // Validate the options
 func (o *MobOptions) Validate() error {
-	if (o.ListOnly || o.PrintVersion) && 1 < len(o.Initials) {
+	if (o.ListOnly || o.PrintVersion) && 0 < len(o.Initials) {
 		return fmt.Errorf("cannot configure a mob while listing availble coauthors or printing the version")
-	}
-
-	if len(o.Initials) < 1 && !o.ListOnly && !o.PrintVersion {
-		return fmt.Errorf("must supply at least one co-author")
 	}
 
 	return o.PrinterOptions.Validate()

--- a/internal/cmd/mob.go
+++ b/internal/cmd/mob.go
@@ -19,6 +19,7 @@ type MobOptions struct {
 	Initials               []string
 	ListOnly               bool
 	PrintVersion           bool
+	CurrentGitUser         *authors.Author
 	AllCoAuthorsByInitials map[string]authors.Author
 }
 
@@ -92,8 +93,10 @@ func (o *MobOptions) Validate() error {
 	}
 
 	if !o.ListOnly && !o.PrintVersion {
-		if _, err := cfg.GetUser(); err != nil {
+		if a, err := cfg.GetUser(); err != nil {
 			return err
+		} else {
+			o.CurrentGitUser = a
 		}
 	}
 
@@ -181,17 +184,12 @@ func (o *MobOptions) setMob() error {
 		// TODO: what do we do here?
 	}
 
-	me, err := cfg.GetUser()
-	if err != nil {
-		return err
-	}
-
 	parts := make([]string, len(o.Initials))
-	meTag := fmt.Sprintf("%s <%s>", me.Name, me.Email)
+	meTag := o.CurrentGitUser.String()
 	for i, initial := range o.Initials {
 		for ii, a := range o.AllCoAuthorsByInitials {
 			if strings.EqualFold(initial, ii) {
-				parts[i] = fmt.Sprintf("%s <%s>", a.Name, a.Email)
+				parts[i] = a.String()
 				break
 			}
 		}

--- a/internal/cmd/mob.go
+++ b/internal/cmd/mob.go
@@ -156,7 +156,7 @@ func (o *MobOptions) setMob() error {
 			}
 		}
 		if coauthors[i].Name == "" {
-			return fmt.Errorf("could not find coauthor with initials '%s'; run 'git mob --list' to see a list of available co-authors", initial)
+			return fmt.Errorf("author with initials '%s' not found; run 'git mob --list' to see a list of available co-authors", initial)
 		}
 	}
 

--- a/internal/cmd/mob.go
+++ b/internal/cmd/mob.go
@@ -171,7 +171,8 @@ func (o *MobOptions) setMob() error {
 		return err
 	}
 	if err := msg.WriteGitMessage(coauthors...); err != nil {
-		return err
+		//return err
+		// TODO: what do we do here?
 	}
 
 	me, err := cfg.GetUser()
@@ -200,8 +201,13 @@ func resetMob() error {
 
 // setCommitTemplate sets the local commit.template config setting to take advantage of `.gitmessage`
 func setCommitTemplate() error {
+	p, err := msg.CommitTemplatePath()
+	if err != nil {
+		return nil
+		// TODO swallowing errors?
+	}
 	if !cfg.Has("commit.template") {
-		return cfg.Set("commit.template", msg.CommitTemplatePath())
+		return cfg.Set("commit.template", p)
 	}
 	return nil
 }

--- a/internal/cmd/mob.go
+++ b/internal/cmd/mob.go
@@ -160,6 +160,9 @@ func (o *MobOptions) setMob() error {
 		}
 	}
 
+	if err := setCommitTemplate(); err != nil {
+		return err
+	}
 	if err := resetMob(); err != nil {
 		return err
 	}
@@ -193,4 +196,12 @@ func (o *MobOptions) setMob() error {
 // resetMob clears out the co-authors from global git config
 func resetMob() error {
 	return cfg.RemoveAllGlobal("git-mob.co-author")
+}
+
+// setCommitTemplate sets the local commit.template config setting to take advantage of `.gitmessage`
+func setCommitTemplate() error {
+	if !cfg.Has("commit.template") {
+		return cfg.Set("commit.template", msg.CommitTemplatePath())
+	}
+	return nil
 }

--- a/internal/cmd/mob.go
+++ b/internal/cmd/mob.go
@@ -6,6 +6,7 @@ import (
 	"github.com/davidalpert/go-git-mob/internal/cfg"
 	"github.com/davidalpert/go-git-mob/internal/cmd/utils"
 	"github.com/davidalpert/go-git-mob/internal/msg"
+	"github.com/davidalpert/go-git-mob/internal/version"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	"sort"
@@ -32,7 +33,16 @@ func NewCmdMob(ioStreams utils.IOStreams) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "mob",
 		Short: "configure co-authors",
-		Args:  cobra.MinimumNArgs(0),
+		Long: fmt.Sprintf(`git-mob %s
+
+A git plugin to help manage git coauthors.
+
+Examples:
+   $ git mob jd                                      # Set John as co-authors
+   $ git solo                                        # Return to working by yourself (i.e. unset all co-authors)
+   $ git mob -l                                      # Show a list of all co-authors, John Doe should be there
+`, version.Detail.Version),
+		Args: cobra.MinimumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(cmd, args); err != nil {
 				return err

--- a/internal/cmd/mob.go
+++ b/internal/cmd/mob.go
@@ -58,6 +58,15 @@ Examples:
 
 	cmd.Flags().BoolVarP(&o.ListOnly, "list", "l", false, "list which co-authors are available")
 
+	cmd.AddCommand(NewCmdMobInit(ioStreams))
+	cmd.AddCommand(NewCmdMobHooks(ioStreams))
+	cmd.AddCommand(NewCmdSolo(ioStreams))
+	cmd.AddCommand(NewCmdCoauthors(ioStreams))
+	cmd.AddCommand(NewCmdExplode(ioStreams))
+	cmd.AddCommand(NewCmdImplode(ioStreams))
+	cmd.AddCommand(NewCmdVersion(ioStreams))
+	cmd.AddCommand(NewCmdPrint(ioStreams))
+
 	return cmd
 }
 

--- a/internal/cmd/mob.go
+++ b/internal/cmd/mob.go
@@ -18,6 +18,7 @@ type MobOptions struct {
 	utils.IOStreams
 	Initials               []string
 	ListOnly               bool
+	PrintVersion           bool
 	AllCoAuthorsByInitials map[string]authors.Author
 }
 
@@ -57,6 +58,7 @@ Examples:
 	o.PrinterOptions.AddPrinterFlags(cmd)
 
 	cmd.Flags().BoolVarP(&o.ListOnly, "list", "l", false, "list which co-authors are available")
+	cmd.Flags().BoolVarP(&o.PrintVersion, "version", "v", false, "print git-mob version")
 
 	cmd.AddCommand(NewCmdMobInit(ioStreams))
 	cmd.AddCommand(NewCmdMobHooks(ioStreams))
@@ -85,11 +87,11 @@ func (o *MobOptions) Complete(cmd *cobra.Command, args []string) error {
 
 // Validate the options
 func (o *MobOptions) Validate() error {
-	if o.ListOnly && 1 < len(o.Initials) {
-		return fmt.Errorf("cannot configure a mob while listing availble coauthors")
+	if (o.ListOnly || o.PrintVersion) && 1 < len(o.Initials) {
+		return fmt.Errorf("cannot configure a mob while listing availble coauthors or printing the version")
 	}
 
-	if len(o.Initials) < 1 && !o.ListOnly {
+	if len(o.Initials) < 1 && !o.ListOnly && !o.PrintVersion {
 		return fmt.Errorf("must supply at least one co-author")
 	}
 
@@ -100,6 +102,12 @@ func (o *MobOptions) Validate() error {
 func (o *MobOptions) Run() error {
 	if o.ListOnly {
 		return o.listCoAuthors()
+	}
+
+	if o.PrintVersion {
+		versionCmd := NewCmdVersion(o.IOStreams)
+		versionCmd.SetArgs([]string{}) // the version command doesn't accept the -v flag
+		return versionCmd.Execute()
 	}
 
 	return o.setMob()

--- a/internal/cmd/mob.go
+++ b/internal/cmd/mob.go
@@ -91,6 +91,12 @@ func (o *MobOptions) Validate() error {
 		return fmt.Errorf("cannot configure a mob while listing availble coauthors or printing the version")
 	}
 
+	if !o.ListOnly && !o.PrintVersion {
+		if _, err := cfg.GetUser(); err != nil {
+			return err
+		}
+	}
+
 	return o.PrinterOptions.Validate()
 }
 

--- a/internal/cmd/mob_hook.go
+++ b/internal/cmd/mob_hook.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/davidalpert/go-git-mob/internal/cmd/utils"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdMobHooks(ioStreams utils.IOStreams) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:     "hooks",
+		Aliases: []string{"hook"},
+		Short:   "git hook utilities",
+		Args:    cobra.NoArgs,
+		//RunE: func(cmd *cobra.Command, args []string) error {
+		//	if err := o.Complete(cmd, args); err != nil {
+		//		return err
+		//	}
+		//	if err := o.Validate(); err != nil {
+		//		return err
+		//	}
+		//	return o.Run()
+		//},
+	}
+
+	//o.PrinterOptions.AddPrinterFlags(cmd)
+
+	//cmd.Flags().BoolVarP(&o.ListOnly, "list", "l", false, "list which co-authors are available")
+
+	cmd.AddCommand(NewCmdMobPrepareCommitMsg(ioStreams))
+
+	return cmd
+}

--- a/internal/cmd/mob_init.go
+++ b/internal/cmd/mob_init.go
@@ -71,7 +71,7 @@ SHA1=$3
 
 set -e
 
-git mob prepare-commit-msg "$COMMIT_MSG_FILE" $COMMIT_SOURCE $SHA1
+git mob hooks prepare-commit-msg "$COMMIT_MSG_FILE" $COMMIT_SOURCE $SHA1
 `
 	if err := os.WriteFile(fileName, []byte(fileContents), 0755); err != nil {
 		return fmt.Errorf("writing git hook: %v", err)

--- a/internal/cmd/mob_init.go
+++ b/internal/cmd/mob_init.go
@@ -61,7 +61,10 @@ func (o *MobInitOptions) Validate() error {
 // Run the command
 func (o *MobInitOptions) Run() error {
 	f := filepath.Join("hooks", "prepare-commit-msg")
-	fileName := revParse.GitPath(f)
+	fileName, err := revParse.GitPath(f)
+	if err != nil {
+		return fmt.Errorf("the 'init' command is only valid inside a local git working directory: %v", err)
+	}
 	fileNameRel := revParse.GitPathRelativeToTopLevelDirectory(f)
 	fileContents := `#!/bin/sh
 

--- a/internal/cmd/print.go
+++ b/internal/cmd/print.go
@@ -30,7 +30,7 @@ func NewCmdPrint(ioStreams utils.IOStreams) *cobra.Command {
 	o := NewPrintOptions(ioStreams)
 	var cmd = &cobra.Command{
 		Use:   "print",
-		Short: "show co-authors",
+		Short: "show current co-authors",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(cmd, args); err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/davidalpert/go-git-mob/internal/cmd/utils"
 	"github.com/davidalpert/go-git-mob/internal/diagnostics"
-	"github.com/davidalpert/go-git-mob/internal/version"
 	"github.com/spf13/cobra"
 	"os"
 )
@@ -56,12 +55,9 @@ func Execute() {
 // NewRootCmd creates the 'root' command and configures it's nested children
 func NewRootCmd(ioStreams utils.IOStreams) *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:   "git-mob",
-		Short: "A git plugin to help manage git coauthors.",
-		Long: fmt.Sprintf(`git-mob %s
-
-A git plugin to help manage git coauthors.
-`, version.Detail.Version),
+		Use:           "git",
+		Short:         "A git plugin to help manage git coauthors.",
+		Long:          "NOTE: this root command is not intended to be run by itself",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		CompletionOptions: cobra.CompletionOptions{

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -75,14 +75,6 @@ func NewRootCmd(ioStreams utils.IOStreams) *cobra.Command {
 
 	// Register subcommands
 	rootCmd.AddCommand(NewCmdMob(ioStreams))
-	rootCmd.AddCommand(NewCmdMobInit(ioStreams))
-	rootCmd.AddCommand(NewCmdMobPrepareCommitMsg(ioStreams))
-	rootCmd.AddCommand(NewCmdSolo(ioStreams))
-	rootCmd.AddCommand(NewCmdCoauthors(ioStreams))
-	rootCmd.AddCommand(NewCmdExplode(ioStreams))
-	rootCmd.AddCommand(NewCmdImplode(ioStreams))
-	rootCmd.AddCommand(NewCmdVersion(ioStreams))
-	rootCmd.AddCommand(NewCmdPrint(ioStreams))
 
 	//rootCmd.PersistentFlags().BoolP("verbose", "vv", false, "enable verbose output")
 

--- a/internal/cmd/solo.go
+++ b/internal/cmd/solo.go
@@ -25,7 +25,7 @@ func NewCmdSolo(ioStreams utils.IOStreams) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "solo",
 		Short: "return to solo work (remove co-authors)",
-		Args:  cobra.NoArgs,
+		Args:  cobra.MinimumNArgs(0), // positional args are allowed (by spec) but ignored
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(cmd, args); err != nil {
 				return err

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -26,7 +26,7 @@ func NewCmdVersion(ioStreams utils.IOStreams) *cobra.Command {
 	o := NewVersionOptions(ioStreams)
 	var cmd = &cobra.Command{
 		Use:   "version",
-		Short: "Show version information",
+		Short: "show version information",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(cmd, args); err != nil {

--- a/internal/msg/message.go
+++ b/internal/msg/message.go
@@ -25,20 +25,32 @@ const (
 	EnvKeyGitMessagePath = "GITMOB_MESSAGE_PATH"
 )
 
-func GitMessagePath() string {
-	return env.GetValueOrDefault(EnvKeyGitMessagePath, revParse.GitPath(".gitmessage"))
+func GitMessagePath() (string, error) {
+	p, err := revParse.GitPath(".gitmessage")
+	if err != nil {
+		return "", err
+	}
+
+	return env.GetValueOrDefault(EnvKeyGitMessagePath, p), nil
 }
 
-func CommitTemplatePath() string {
+func CommitTemplatePath() (string, error) {
 	s := env.GetValueOrDefaultString(EnvKeyGitMessagePath, cfg.Get("commit.template"))
 	if s == "" {
-		s = GitMessagePath()
+		ss, err := GitMessagePath()
+		if err != nil {
+			return "", err
+		}
+		return ss, nil
 	}
-	return s
+	return s, nil
 }
 
 func WriteGitMessage(coAuthorList ...authors.Author) error {
-	p := GitMessagePath()
+	p, err := GitMessagePath()
+	if err != nil {
+		return err
+	}
 
 	content := "\n" + "\n" + FormatCoAuthorList(coAuthorList)
 

--- a/internal/msg/message.go
+++ b/internal/msg/message.go
@@ -42,5 +42,19 @@ func WriteGitMessage(coAuthorList ...authors.Author) error {
 
 	content := "\n" + "\n" + FormatCoAuthorList(coAuthorList)
 
+	if _, err := os.Stat(p); err == nil {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return fmt.Errorf("reading git message file: %v", err)
+		}
+
+		i := strings.Index(string(b), "\n\nCo-authored-by:")
+		if i > 0 {
+			content = string(b[:i]) + content
+		} else {
+			content = string(b) + content
+		}
+	}
+
 	return ioutil.WriteFile(p, []byte(content), os.ModePerm)
 }

--- a/internal/revParse/paths.go
+++ b/internal/revParse/paths.go
@@ -19,21 +19,21 @@ func InsideWorkTree() bool {
 }
 
 // TopLevelDirectory computes the path to the top-level directory of the git repository.
-func TopLevelDirectory() string {
+func TopLevelDirectory() (string, error) {
 	r, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{
 		DetectDotGit:          true,
 		EnableDotGitCommonDir: false,
 	})
 	if err != nil {
-		panic(err)
+		return "", err
 	}
 
 	w, err := r.Worktree()
 	if err != nil {
-		panic(err)
+		return "", err
 	}
 
-	return w.Filesystem.Root()
+	return w.Filesystem.Root(), nil
 }
 
 // GitPath resolves the given path to the .git directory (GIT_DIR).
@@ -41,8 +41,12 @@ func TopLevelDirectory() string {
 // GIT_DIR is the location of the .git folder. If this isn’t specified,
 // Git walks up the directory tree until it gets to ~ or /, looking for a
 // .git directory at every step.
-func GitPath(rel ...string) string {
-	return path.Join(append([]string{TopLevelDirectory(), ".git"}, rel...)...)
+func GitPath(rel ...string) (string, error) {
+	tld, err := TopLevelDirectory()
+	if err != nil {
+		return "", err
+	}
+	return path.Join(append([]string{tld, ".git"}, rel...)...), nil
 }
 
 func GitPathRelativeToTopLevelDirectory(rel ...string) string {


### PR DESCRIPTION
loops through the node spec tests in nodejs "git-mob" and ensures that "go-git-mob" behaves the same in all but one aspect:
- by default we store coauthors in "~/.gitconfig" so that the mob persists across different working trees used in the same session