### PR TITLE
build: fix bundled version number

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,6 +15,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2 # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
 
+    - name: Fetch all tags
+      run: git fetch --force --tags
+
     - name: Setup Reviewdog
       uses: reviewdog/action-setup@v1
       with:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECTNAME=go-git-mob
+PROJECTNAME=git-mob
 
 # Make is verbose in Linux. Make it silent.
 MAKEFLAGS += --silent


### PR DESCRIPTION
the core of the issue was that our Makefile was invoking
$(make) gen and that in tern was invoking go generate
and neither was propegating env vars in the way I had
expected.

this pattern appears to allow setting the version on
the command line during a build as expected

    make build VERSION=1.2.3

NOTE: manually setting the core version numbers when
      running build like this is not recommended
      for common use; it is however required by
      the make release targets

resolves #43