### PR TITLE
feat: overwrite the main author

### DIFF
--- a/features/git-mob/parity/git-mob.feature
+++ b/features/git-mob/parity/git-mob.feature
@@ -86,16 +86,23 @@ Feature: git-mob.spec
       Amy Doe <amy@example.com>
       """
 
-  @pending
   # issue #7 https://github.com/davidalpert/go-git-mob/issues/7
-  # NOTE: the -o flag is already in use for --output; will need
-  #       to either pick a different shortcut for the override
-  #       command or disable output formatting; I would prefer
-  #       to use a different flag peraps even --o
   Scenario: sets mob and override coauthor
     Given I cd to "example"
-    When I successfully run `git mob -o ad bd`
-    Then the output should contain:
+    When I successfully run `git mob --override-author ad bd`
+    Then the current git author should be "Amy Doe" "amy@example.com"
+    And the output should contain:
+      """
+      Amy Doe <amy@example.com>
+      Bob Doe <bob@example.com>
+      """
+
+  # issue #7 https://github.com/davidalpert/go-git-mob/issues/7
+  Scenario: sets mob and override coauthor
+    Given I cd to "example"
+    When I successfully run `git mob -a ad bd`
+    Then the current git author should be "Amy Doe" "amy@example.com"
+    And the output should contain:
       """
       Amy Doe <amy@example.com>
       Bob Doe <bob@example.com>

--- a/features/step_definitions/co-author_steps.rb
+++ b/features/step_definitions/co-author_steps.rb
@@ -16,3 +16,23 @@ Then(/^(?:a|the) file(?: named)? "([^"]*)" should (not )?include these coauthors
     expect(@actual["coauthors"]).to include(@expected)
   end
 end
+
+Then('the current git author should be {string} {string}') do |name, email|
+  run_command_and_validate_channel(
+    cmd: 'git config user.name',
+    fail_on_error: true,
+    channel: 'stdout',
+    negated: false,
+    match_as_regex: false,
+    content: name
+  )
+
+  run_command_and_validate_channel(
+    cmd: 'git config user.email',
+    fail_on_error: true,
+    channel: 'stdout',
+    negated: false,
+    match_as_regex: false,
+    content: email
+  )
+end

--- a/internal/gitMobCommands/domain.go
+++ b/internal/gitMobCommands/domain.go
@@ -69,12 +69,23 @@ func GetGitAuthor() (*authors.Author, error) {
 	}, err
 }
 
-// SetGitAuthor sets the primary git author from the given authors.Author
+// SetGitAuthor sets the primary git author locally from the given authors.Author
 func SetGitAuthor(a *authors.Author) error {
 	if err := gitConfig.Set("user.name", a.Name); err != nil {
 		return err
 	}
 	if err := gitConfig.Set("user.email", a.Email); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetGitAuthorGlobal sets the primary git author globally from the given authors.Author
+func SetGitAuthorGlobal(a *authors.Author) error {
+	if err := gitConfig.SetGlobal("user.name", a.Name); err != nil {
+		return err
+	}
+	if err := gitConfig.SetGlobal("user.email", a.Email); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
`git mob --override-author` allows you to override the author for this commit message and updates the primary git author on the local machine

useful when passing a single laptop to a new author while mobbing in-person

resolves #7 