### PR TITLE
fix: expose missing output when subprocess exit code is non-zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
   - [Uninstall](#uninstall)
 - [Usage](#usage)
   - [Sub-command help](#sub-command-help)
+- [Troubleshooting](#troubleshooting)
 - [Roadmap](#roadmap)
 - [Contributing](#contributing)
 - [License](#license)
@@ -183,6 +184,27 @@ Usage:
   git mob [command]
 
 Use "git-mob [command] -h" for more information about a command.
+```
+
+<!-- Troubleshooting -->
+## Troubleshooting
+
+If you run into trouble you can ask `go-git-mob` to write some diagnostics to a log file by setting the following environment variables:
+
+| Variable          | Default   | Description                                                      |
+| ----------------- | --------- | ---------------------------------------------------------------- |
+| GITMOB_LOG_LEVEL  | `"fatal"` | `"fatal"`, `"error"`, `"warning"`, `"warn"`, `"info"`, `"debug"` |
+| GITMOB_LOG_FORMAT | `"text"`  | `"text"` or `"json"`                                             |
+| GITMOB_LOG_FILE   | `""`      | path to a log file; when empty logs go to STDOUT                 |
+
+Dial up log levels to show more detail:
+```
+GITMOB_LOG_LEVEL=debug git commit -m "my log message"
+```
+
+Capture log messages to a file:
+```
+GITMOB_LOG_FILE=./mob.log GITMOB_LOG_LEVEL=debug git commit -m "my log message"
 ```
 
 <!-- ROADMAP -->

--- a/features/git-mob/logging.feature
+++ b/features/git-mob/logging.feature
@@ -1,4 +1,5 @@
-# @wip @announce-stdout @announce-git-log
+# @announce-stdout
+@announce-gitmob-log
 Feature: logging support
 
   Background:

--- a/features/git-mob/mob-appends-coauthors-to-commits.feature
+++ b/features/git-mob/mob-appends-coauthors-to-commits.feature
@@ -24,7 +24,7 @@ Feature: git mob appends coauthors to commits
       """
     And a simple git repo at "example"
 
-  # @announce-git-log
+  # @announce-gitmob-log
   Scenario: append coauthor to a commit with the message flag
     Given I cd to "example"
     And I successfully run `git mob init`

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -4,8 +4,8 @@ Before('@announce-paths') do
   aruba.announcer.activate :paths
 end
 
-Before('@announce-git-log') do
-  aruba.announcer.activate :git_log
+Before('@announce-gitmob-log') do
+  aruba.announcer.activate :gitmob_log
 end
 
 Before('@windows-only') do
@@ -34,4 +34,11 @@ Before do
 end
 
 After do
+  aruba.announcer.announce(:gitmob_log, '<<-GITMOB_LOG')
+  if aruba.environment['GITMOB_LOG_FILE']
+    aruba.announcer.announce(:gitmob_log, File.read(expand_path(aruba.environment['GITMOB_LOG_FILE'])))
+  else
+    aruba.announcer.announce(:gitmob_log, "git-mob logs are available as STDOUT; use @announce-stdout")
+  end
+  aruba.announcer.announce(:gitmob_log, 'GITMOB_LOG')
 end

--- a/internal/diagnostics/log.go
+++ b/internal/diagnostics/log.go
@@ -1,7 +1,6 @@
 package diagnostics
 
 import (
-	"fmt"
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/json"
 	"github.com/davidalpert/go-git-mob/internal/diagnostics/plaintext"
@@ -40,6 +39,7 @@ func ConfigureLogger(streams printers.IOStreams) (cleanupFn func()) {
 	// log sink
 	var sink io.Writer
 	var logFile = env.GetValueOrDefaultString(ENVKEY_LOG_FILE, "")
+	var logDestination = "stdout"
 	if logFile == "" {
 		sink = streams.Out
 	} else {
@@ -52,9 +52,7 @@ func ConfigureLogger(streams printers.IOStreams) (cleanupFn func()) {
 			log.Fatal(err.Error())
 		}
 		cleanupFn = func() { logFile.Close() }
-		if logLevel == log.DebugLevel {
-			fmt.Fprintln(streams.Out, "logging to:", fullPath)
-		}
+		logDestination = fullPath
 		sink = logFile
 	}
 
@@ -64,7 +62,7 @@ func ConfigureLogger(streams printers.IOStreams) (cleanupFn func()) {
 		log.SetHandler(plaintext.New(sink))
 	}
 
-	Log.Debug("logging initialized")
+	Log.WithField("destination", logDestination).Debug("logging initialized")
 
 	return
 }

--- a/internal/diagnostics/log.go
+++ b/internal/diagnostics/log.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/json"
-	"github.com/davidalpert/go-printers/v1"
 	"github.com/davidalpert/go-git-mob/internal/diagnostics/plaintext"
 	"github.com/davidalpert/go-git-mob/internal/env"
 	"github.com/davidalpert/go-git-mob/internal/version"
+	"github.com/davidalpert/go-printers/v1"
 	"io"
 	"os"
 	"path/filepath"
@@ -20,7 +20,6 @@ const (
 	ENVKEY_LOG_LEVEL  = "GITMOB_LOG_LEVEL"
 	ENVKEY_LOG_FORMAT = "GITMOB_LOG_FORMAT"
 	ENVKEY_LOG_FILE   = "GITMOB_LOG_FILE"
-	ENVKEY_DEBUG      = "GITMOB_DEBUG"
 )
 
 func init() {
@@ -36,7 +35,8 @@ func ConfigureLogger(streams printers.IOStreams) (cleanupFn func()) {
 	cleanupFn = func() {}
 
 	// configure logging
-	log.SetLevel(env.GetValueOrDefaultLogLevel(ENVKEY_LOG_LEVEL, log.FatalLevel))
+	logLevel := env.GetValueOrDefaultLogLevel(ENVKEY_LOG_LEVEL, log.FatalLevel)
+	log.SetLevel(logLevel)
 	// log sink
 	var sink io.Writer
 	var logFile = env.GetValueOrDefaultString(ENVKEY_LOG_FILE, "")
@@ -52,8 +52,8 @@ func ConfigureLogger(streams printers.IOStreams) (cleanupFn func()) {
 			log.Fatal(err.Error())
 		}
 		cleanupFn = func() { logFile.Close() }
-		if env.GetValueOrDefaultBool(ENVKEY_DEBUG, false) {
-			fmt.Println("logging to:", fullPath)
+		if logLevel == log.DebugLevel {
+			fmt.Fprintln(streams.Out, "logging to:", fullPath)
 		}
 		sink = logFile
 	}


### PR DESCRIPTION
this removes the GITMOB_DEBUG option; I was torn here because
GITMOB_DEBUG is simpler in concept but not as flexible and we
don't need two ways to enable log message

this also leans into the diagnostic.Log interface foregoing direct
STDOUT (which is where the logger defaults to anyway) in favour
of a lower GITMOB_LOG_LEVEL