### PR TITLE
feat: raise error on duplicate coauthors initials

### DIFF
--- a/features/git-mob/validation-warns-of-duplicate-coauthor-keys.feature
+++ b/features/git-mob/validation-warns-of-duplicate-coauthor-keys.feature
@@ -1,0 +1,34 @@
+Feature: Validation warns of duplicate coauthor keys
+
+  Background:
+    Given I have installed git-mob into "local_bin" within the current directory
+    And I look for executables in "local_bin" within the current directory
+
+    And I run `git config --global user.name "Jane Doe"`
+    And I run `git config --global user.email "jane@example.com"`
+
+  Scenario: list fails with duplicate intinitials
+    Given a file named "~/.git-coauthors" with:
+      """
+      {
+        "coauthors": {
+          "ad": {
+            "name": "Amy Doe",
+            "email": "amy@example.com"
+          },
+          "ad": {
+            "name": "Arnold Doe",
+            "email": "arnold@example.com"
+          }
+        }
+      }
+      """
+    When I run `git mob --list`
+    Then the exit status should be 1
+    And the stderr should contain:
+      """
+      ad Amy Doe amy@example.com
+      ad Arnold Doe arnold@example.com
+
+      duplicate coauthor initials found
+      """

--- a/internal/authors/coauthors_file_content.go
+++ b/internal/authors/coauthors_file_content.go
@@ -1,8 +1,12 @@
 package authors
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -27,6 +31,12 @@ func ReadCoAuthorsContentFromFilePath(filePath string) (CoAuthorsFileContent, er
 
 func ReadCoAuthorsContentFromBytes(b []byte) (CoAuthorsFileContent, error) {
 	var c CoAuthorsFileContent
+	if _, err := checkJsonBytesForDuplicateCoauthors(b); err != nil {
+		//if errors.Is(err, ErrDuplicateCoauthorInitialsFound) {
+		//	fmt.Printf("found duplicates: %#v\n", duplicateAuthorsByInitial)
+		//}
+		return c, err
+	}
 	err := json.Unmarshal(b, &c)
 	return c, err
 }
@@ -92,4 +102,125 @@ func WriteCoauthorsContentToFilePath(path string, cc CoAuthorsFileContent) error
 	}
 
 	return os.WriteFile(path, b, os.ModePerm)
+}
+
+func checkJsonBytesForDuplicateCoauthors(b []byte) (map[string][]Author, error) {
+	return check(json.NewDecoder(bytes.NewReader(b)), nil)
+}
+
+func check(d *json.Decoder, path []string) (map[string][]Author, error) {
+	// Get the next token
+	t, err := d.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	// Is it a delimiter?
+	delim, ok := t.(json.Delim)
+	// No, nothing more to check.
+	if !ok {
+		// scalar type, nothing to do
+		return nil, nil
+	}
+
+	switch delim {
+	case '{':
+		for d.More() {
+
+			// Get field key.
+			t, err := d.Token()
+			if err != nil {
+				return nil, err
+			}
+			key := t.(string)
+
+			if key == "coauthors" {
+				return checkCoauthorsObjectForDuplicatesByInitials(d, append(path, key))
+			}
+
+			// Check value.
+			if _, err := check(d, append(path, key)); err != nil {
+				return nil, err
+			}
+		}
+		// consume trailing }
+		if _, err := d.Token(); err != nil {
+			return nil, err
+		}
+
+	case '[':
+		i := 0
+		for d.More() {
+			if _, err := check(d, append(path, strconv.Itoa(i))); err != nil {
+				return nil, err
+			}
+			i++
+		}
+		// consume trailing ]
+		if _, err := d.Token(); err != nil {
+			return nil, err
+		}
+
+	}
+	return nil, nil
+}
+
+var ErrDuplicateCoauthorInitialsFound = errors.New("duplicate coauthor initials found")
+
+func checkCoauthorsObjectForDuplicatesByInitials(d *json.Decoder, path []string) (map[string][]Author, error) {
+	parsedCoauthors := make(map[string][]Author, 0)
+	duplicateInitials := make(map[string][]Author, 0)
+
+	// consume the opening '{'
+	t, err := d.Token()
+	if err != nil {
+		return nil, err
+	}
+	delim, ok := t.(json.Delim)
+	if !(ok && delim == '{') {
+		return nil, fmt.Errorf("expected an opening { after \"coauthors\"")
+	}
+
+	for d.More() {
+		// get an initials key
+		t, err = d.Token()
+		if err != nil {
+			return nil, err
+		}
+		key := t.(string)
+
+		if _, ok = parsedCoauthors[key]; !ok {
+			parsedCoauthors[key] = make([]Author, 0)
+		}
+
+		var a Author
+		if err2 := d.Decode(&a); err2 != nil {
+			return nil, err2
+		}
+		//fmt.Printf("found: %#v: %#v\n", key, a)
+		parsedCoauthors[key] = append(parsedCoauthors[key], a)
+	}
+
+	// consume the closing '}'
+	t, err = d.Token()
+	if err != nil {
+		return nil, err
+	}
+	delim, ok = t.(json.Delim)
+	if !(ok && delim == '}') {
+		return nil, fmt.Errorf("expected an closing } at the end of  \"coauthors\"")
+	}
+
+	var foundDuplicates = false
+	for k, aa := range parsedCoauthors {
+		if len(aa) > 1 {
+			foundDuplicates = true
+			duplicateInitials[k] = aa
+		}
+	}
+
+	if foundDuplicates {
+		return duplicateInitials, ErrDuplicateCoauthorInitialsFound
+	}
+	return nil, nil
 }


### PR DESCRIPTION
golang json demarshalling ignores duplicate keys allowing
the last key found to overwrite previous keys. This means
that if you add multiple coauthors with the same initials only
the last instance of each initial becomes accessible and
previous instances of that initial are silently ignored.

This can cause unintended behavior when configuring
a mob so now we return a validation error effectively
stating that since we cannot concretely determine the
end-users intention we will bail with some useful error
detail.

resolves #45 