### PR TITLE
feat: git mob now works outside a working tree

### DIFF
--- a/features/git-mob/mob.feature
+++ b/features/git-mob/mob.feature
@@ -86,6 +86,15 @@ Feature: mob
       Bob Doe <bob@findmypast.com>
       """
 
+  Scenario: mob with no args outside a working tree prints the current mob
+    Given I successfully run `git mob bd`
+    When I successfully run `git mob`
+    Then the stdout from "git mob" should contain:
+      """
+      Jane Doe <jane@example.com>
+      Bob Doe <bob@findmypast.com>
+      """
+
   Scenario: no git-coauthors file
     Given I remove the file "~/.git-coauthors"
     And I cd to "example"

--- a/internal/cmd/mob.go
+++ b/internal/cmd/mob.go
@@ -8,7 +8,6 @@ import (
 	"github.com/davidalpert/go-git-mob/internal/gitConfig"
 	"github.com/davidalpert/go-git-mob/internal/gitMessage"
 	"github.com/davidalpert/go-git-mob/internal/gitMobCommands"
-	"github.com/davidalpert/go-git-mob/internal/revParse"
 	"github.com/davidalpert/go-git-mob/internal/version"
 	"github.com/davidalpert/go-printers/v1"
 	"github.com/olekukonko/tablewriter"
@@ -116,9 +115,6 @@ func (o *MobOptions) Validate() error {
 	}
 
 	if !o.ListOnly && !o.PrintVersion {
-		if !revParse.InsideWorkTree() {
-			return fmt.Errorf("not inside a git repository working tree")
-		}
 		if a, err := gitMobCommands.GetGitAuthor(); err != nil {
 			return err // includes configWarning
 		} else {


### PR DESCRIPTION
now that git mob is largely decoupled from individual repos storing the current mob in global gitconfig so a mob can follow from one repo to another and no longer relying on or requiring local commit templates there is no reason to restrict the 'git mob' subcommand to only work inside a working tree

in fact it is quite common to run that command outside of a working tree, especially when setting up or learning to use go-git-mob

resolve #82