### PR TITLE
docs: add shell one-liner to verify that GOPATH bin is in your PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ With a working golang installation at version >= 1.16 you can install or update 
 go install github.com/davidalpert/go-git-mob/cmd/git-mob@latest
 ```
 
+Ensure that your path contains the GOPATH bin folder:
+
+```
+if [[ ":$PATH:" == *":$(go env GOPATH)/bin:"* ]]; then echo "your path is correctly set"; else echo "your path is missing $(go env GOPATH)/bin; please add it"; fi
+```
+
 #### Pre-compiled binaries
 
 Visit the [Releases](https://github.com/davidalpert/go-git-mob/releases) page to find binary packages pre-compiled for a variety of `GOOS` and `GOARCH` combinations:


### PR DESCRIPTION
go install builds binaries and copies them into $GOPATH/bin

this one-liner shell command tests that GOPATH/bin is included in PATH and warns if it is not