### PR TITLE
fix: managing coauthors does not need to be in a working tree

### DIFF
--- a/internal/cmd/coauthors_add.go
+++ b/internal/cmd/coauthors_add.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/davidalpert/go-git-mob/internal/authors"
 	"github.com/davidalpert/go-git-mob/internal/gitConfig"
-	"github.com/davidalpert/go-git-mob/internal/revParse"
 	"github.com/davidalpert/go-printers/v1"
 	"github.com/spf13/cobra"
 	"net/mail"
@@ -65,10 +64,6 @@ func (o *CoauthorsAddOptions) Complete(cmd *cobra.Command, args []string) error 
 
 // Validate the options
 func (o *CoauthorsAddOptions) Validate() error {
-	if !revParse.InsideWorkTree() {
-		return fmt.Errorf("not a git repository")
-	}
-
 	if _, err := mail.ParseAddress(o.Author.Email); err != nil {
 		return fmt.Errorf("invalid email address: %v", err)
 	}

--- a/internal/cmd/coauthors_delete.go
+++ b/internal/cmd/coauthors_delete.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/davidalpert/go-git-mob/internal/authors"
 	"github.com/davidalpert/go-git-mob/internal/gitConfig"
-	"github.com/davidalpert/go-git-mob/internal/revParse"
 	"github.com/davidalpert/go-printers/v1"
 	"github.com/spf13/cobra"
 	"strings"
@@ -60,10 +59,6 @@ func (o *CoauthorsDeleteOptions) Complete(cmd *cobra.Command, args []string) err
 
 // Validate the options
 func (o *CoauthorsDeleteOptions) Validate() error {
-	if !revParse.InsideWorkTree() {
-		return fmt.Errorf("not a git repository")
-	}
-
 	var foundExisting = ""
 	for ii, _ := range o.AllCoAuthorsByInitials {
 		if strings.EqualFold(o.AuthorInitials, ii) {

--- a/internal/cmd/coauthors_edit.go
+++ b/internal/cmd/coauthors_edit.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/davidalpert/go-git-mob/internal/authors"
 	"github.com/davidalpert/go-git-mob/internal/gitConfig"
-	"github.com/davidalpert/go-git-mob/internal/revParse"
 	"github.com/davidalpert/go-printers/v1"
 	"github.com/spf13/cobra"
 	"net/mail"
@@ -64,10 +63,6 @@ func (o *CoauthorsEditOptions) Complete(cmd *cobra.Command, args []string) error
 
 // Validate the options
 func (o *CoauthorsEditOptions) Validate() error {
-	if !revParse.InsideWorkTree() {
-		return fmt.Errorf("not a git repository")
-	}
-
 	if o.AuthorEmail != "" {
 		if _, err := mail.ParseAddress(o.AuthorEmail); err != nil {
 			return fmt.Errorf("invalid email address: %v", err)

--- a/internal/cmd/coauthors_suggest.go
+++ b/internal/cmd/coauthors_suggest.go
@@ -51,7 +51,7 @@ func (o *CoauthorsSuggestOptions) Complete(cmd *cobra.Command, args []string) er
 // Validate the options
 func (o *CoauthorsSuggestOptions) Validate() error {
 	if !revParse.InsideWorkTree() {
-		return fmt.Errorf("not a git repository")
+		return fmt.Errorf("not a git repository; suggesting co-authors requires a commit history")
 	}
 
 	return o.PrinterOptions.Validate()


### PR DESCRIPTION
as the coauthors are stored globally, not locally, there is no requirement that you be in a working tree (i.e. local git repo/folder) to add or remove or update a coauthor from the ~/.git-coauthors file

the suggest-coauthors feature however does require that it is in a working tree as it scans the commit history of the current repo to suggest coauthors based on who has contributed commits to the repo.