### PR TITLE
test: example bug feature

### DIFF
--- a/features/git-mob/bugs/89-co-authors-not-cleared-from-message-template-when-returning-to-git-solo.feature
+++ b/features/git-mob/bugs/89-co-authors-not-cleared-from-message-template-when-returning-to-git-solo.feature
@@ -1,0 +1,38 @@
+Feature: 🐛 co-authors not cleared from message template when returning to git solo
+
+  Background:
+    Given I have installed git-mob into "local_bin" within the current directory
+    And I look for executables in "local_bin" within the current directory
+
+    Given a file named "~/.gitconfig" with:
+      """
+      [user]
+      name = Jane Doe
+      email = jane@example.com
+      """
+
+    And a file named "~/.git-coauthors" with:
+      """
+      {
+        "coauthors": {
+          "ad": {
+            "name": "Amy Doe",
+            "email": "amy@findmypast.com"
+          },
+          "bd": {
+            "name": "Bob Doe",
+            "email": "bob@findmypast.com"
+          }
+        }
+      }
+      """
+
+  Scenario: 
+    Given I successfully run `git mob ad`
+    And the file "~/.gitmessage" should contain:
+      """
+
+      Co-authored-by: Amy Doe <amy@findmypast.com>
+      """
+    When I successfully run `git solo`
+    And the file "~/.gitmessage" should not contain "Co-authored-by"


### PR DESCRIPTION
demonstrates #89

fails with:
```
  Scenario:                                                          # features/git-mob/bugs/89-co-authors-not-cleared-from-message-template-when-returning-to-git-solo.feature:30
    Given I successfully run `git mob ad`                            # aruba-2.0.0/lib/aruba/cucumber/command.rb:10
    And the file "~/.gitmessage" should contain:                     # aruba-2.0.0/lib/aruba/cucumber/file.rb:157
      """

      Co-authored-by: Amy Doe <amy@findmypast.com>
      """
    When I successfully run `git solo`                               # aruba-2.0.0/lib/aruba/cucumber/command.rb:10
    And the file "~/.gitmessage" should not contain "Co-authored-by" # aruba-2.0.0/lib/aruba/cucumber/file.rb:148
      expected "\n\nCo-authored-by: Amy Doe <amy@findmypast.com>" not to have file content: string includes: "Co-authored-by" (RSpec::Expectations::ExpectationNotMetError)
      features/git-mob/bugs/89-co-authors-not-cleared-from-message-template-when-returning-to-git-solo.feature:38:in `the file "~/.gitmessage" should not contain "Co-authored-by"'
```